### PR TITLE
feat: 全ページをモバイルファースト・レスポンシブ対応

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function AnalyticsPage() {
+  return (
+    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+      <div className="max-w-4xl mx-auto">
+        <Link href="/" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors">
+          &larr; ホーム
+        </Link>
+        <h1 className="text-2xl font-bold text-slate-100 mb-2">分析</h1>
+        <p className="text-slate-500 mb-8">Phase 3で実装予定</p>
+
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-12 text-center">
+          <p className="text-slate-400">損益チャート・敗因分析・IV相関ダッシュボードを準備中</p>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
         </div>
 
         {/* Features */}
-        <div className="mt-12 grid grid-cols-3 gap-4 text-center">
+        <div className="mt-12 grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
           {[
             { label: 'IV分析', desc: 'ブラック・ショールズ' },
             { label: 'LINE通知', desc: '買い時シグナル' },

--- a/src/app/trades/[id]/edit/page.tsx
+++ b/src/app/trades/[id]/edit/page.tsx
@@ -168,7 +168,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <label className={labelClass}>取引日 *</label>
                     <input name="trade_date" type="date" required defaultValue={trade.trade_date} className={inputClass} />
@@ -179,7 +179,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <label className={labelClass}>権利行使価格 *</label>
                     <input name="strike_price" type="number" required defaultValue={trade.strike_price} className={inputClass} />
@@ -190,7 +190,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <label className={labelClass}>購入価格 *</label>
                     <input name="entry_price" type="number" step="0.01" required defaultValue={trade.entry_price} className={inputClass} />
@@ -212,7 +212,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
           {/* 決済情報（編集・決済共通） */}
           <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
             <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">決済情報</h2>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>決済価格</label>
                 <input

--- a/src/app/trades/new/page.tsx
+++ b/src/app/trades/new/page.tsx
@@ -96,7 +96,7 @@ export default function NewTradePage() {
               <input type="hidden" name="trade_type" value={tradeType} />
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>取引日 *</label>
                 <input
@@ -118,7 +118,7 @@ export default function NewTradePage() {
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>権利行使価格 *</label>
                 <input
@@ -146,7 +146,7 @@ export default function NewTradePage() {
           {/* Section: 価格 */}
           <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
             <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">価格</h2>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>購入価格（プレミアム）*</label>
                 <input
@@ -169,7 +169,7 @@ export default function NewTradePage() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>決済価格（任意）</label>
                 <input

--- a/src/app/trades/page.tsx
+++ b/src/app/trades/page.tsx
@@ -40,7 +40,7 @@ export default async function TradesPage() {
 
         {/* Stats */}
         {trades.length > 0 && (
-          <div className="grid grid-cols-3 gap-3 mb-6">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
             <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
               <p className="text-xs text-slate-300 mb-1">累計損益</p>
               <p className={`text-xl font-bold tabular-nums ${totalPnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
@@ -85,20 +85,60 @@ export default async function TradesPage() {
               <Link
                 key={trade.id}
                 href={`/trades/${trade.id}`}
-                className="group flex items-center gap-4 bg-slate-900 border border-slate-800 hover:border-slate-700 hover:bg-slate-800/60 rounded-xl px-4 py-3.5 transition-all duration-150"
+                className="group flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 bg-slate-900 border border-slate-800 hover:border-slate-700 hover:bg-slate-800/60 rounded-xl px-4 py-3.5 transition-all duration-150"
               >
-                {/* Type Badge */}
-                <div className={`flex-shrink-0 w-14 text-center text-xs font-bold py-1 rounded-lg ${
-                  trade.trade_type === 'call'
-                    ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                    : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
-                }`}>
-                  {trade.trade_type.toUpperCase()}
+                {/* Mobile: top row with badge + PnL */}
+                <div className="flex items-center justify-between sm:contents">
+                  {/* Type Badge */}
+                  <div className={`flex-shrink-0 w-14 text-center text-xs font-bold py-1 rounded-lg ${
+                    trade.trade_type === 'call'
+                      ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
+                      : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
+                  }`}>
+                    {trade.trade_type.toUpperCase()}
+                  </div>
+
+                  {/* Info */}
+                  <div className="hidden sm:block flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-white">
+                        {trade.strike_price.toLocaleString()}円
+                      </span>
+                      <span className="text-xs text-slate-400">×{trade.quantity}枚</span>
+                      {trade.iv_at_entry !== null && (
+                        <span className="text-xs text-slate-400">IV {trade.iv_at_entry}%</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 mt-0.5">
+                      <span className="text-xs text-slate-300">{trade.trade_date}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${
+                        trade.status === 'open'
+                          ? 'text-amber-400 bg-amber-500/10'
+                          : 'text-slate-500 bg-slate-800'
+                      }`}>
+                        {trade.status === 'open' ? '未決済' : '決済済'}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* PnL */}
+                  <div className="flex-shrink-0 text-right flex items-center gap-2">
+                    {trade.pnl !== null ? (
+                      <span className={`text-sm font-semibold tabular-nums ${
+                        trade.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'
+                      }`}>
+                        {trade.pnl >= 0 ? '+' : ''}{trade.pnl.toLocaleString()}円
+                      </span>
+                    ) : (
+                      <span className="text-xs text-slate-400">@ {trade.entry_price}</span>
+                    )}
+                    <span className="text-slate-700 group-hover:text-slate-500 transition-colors text-sm flex-shrink-0">›</span>
+                  </div>
                 </div>
 
-                {/* Info */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
+                {/* Mobile: info row */}
+                <div className="sm:hidden">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-sm font-medium text-white">
                       {trade.strike_price.toLocaleString()}円
                     </span>
@@ -106,8 +146,6 @@ export default async function TradesPage() {
                     {trade.iv_at_entry !== null && (
                       <span className="text-xs text-slate-400">IV {trade.iv_at_entry}%</span>
                     )}
-                  </div>
-                  <div className="flex items-center gap-2 mt-0.5">
                     <span className="text-xs text-slate-300">{trade.trade_date}</span>
                     <span className={`text-xs px-1.5 py-0.5 rounded ${
                       trade.status === 'open'
@@ -118,21 +156,6 @@ export default async function TradesPage() {
                     </span>
                   </div>
                 </div>
-
-                {/* PnL */}
-                <div className="flex-shrink-0 text-right">
-                  {trade.pnl !== null ? (
-                    <span className={`text-sm font-semibold tabular-nums ${
-                      trade.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'
-                    }`}>
-                      {trade.pnl >= 0 ? '+' : ''}{trade.pnl.toLocaleString()}円
-                    </span>
-                  ) : (
-                    <span className="text-xs text-slate-400">@ {trade.entry_price}</span>
-                  )}
-                </div>
-
-                <span className="text-slate-700 group-hover:text-slate-500 transition-colors text-sm flex-shrink-0">›</span>
               </Link>
             ))}
           </div>


### PR DESCRIPTION
## Related Issue
Closes #5

## Summary
- 統計グリッド（trades/page.tsx）を `grid-cols-1 sm:grid-cols-3` に変更
- フォームグリッド（new/edit）を `grid-cols-1 sm:grid-cols-2` に変更
- 取引リストを `flex-col sm:flex-row` で小画面スタッキング対応
- ホーム画面のカードグリッドもレスポンシブ化
- アナリティクスページをダークテーマに統一

## Test plan
- 320px幅（iPhone SE）でテキストが切れないことを確認
- 768px幅（iPad）で適切にレイアウトされることを確認
- ダークテーマが全ページ統一されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)