### PR TITLE
refactor: クライアント側Supabase操作をServer Actionsに移行

### DIFF
--- a/src/app/actions/trades.ts
+++ b/src/app/actions/trades.ts
@@ -1,0 +1,133 @@
+'use server'
+
+import { supabase } from '@/lib/supabase'
+import { revalidatePath } from 'next/cache'
+import { calculatePnl } from '@/lib/trade'
+import type { TradeType } from '@/types/database'
+
+export type TradeActionResult =
+  | { success: true }
+  | { success: false; error: string }
+
+interface CreateTradeInput {
+  trade_date: string
+  trade_type: TradeType
+  strike_price: number
+  expiry_date: string
+  quantity: number
+  entry_price: number
+  exit_price: number | null
+  exit_date: string | null
+  iv_at_entry: number | null
+  memo: string | null
+}
+
+interface UpdateTradeInput {
+  trade_date: string
+  trade_type: TradeType
+  strike_price: number
+  expiry_date: string
+  quantity: number
+  entry_price: number
+  exit_price: number | null
+  exit_date: string | null
+  iv_at_entry: number | null
+  memo: string | null
+}
+
+function validateTradeInput(data: CreateTradeInput | UpdateTradeInput): string | null {
+  if (!data.trade_date) return '取引日は必須です'
+  if (!data.trade_type || !['call', 'put'].includes(data.trade_type)) return '種別はcallまたはputを指定してください'
+  if (!data.strike_price || data.strike_price <= 0) return '権利行使価格は正の数を指定してください'
+  if (!data.expiry_date) return '限月（SQ日）は必須です'
+  if (!data.quantity || data.quantity < 1) return '枚数は1以上を指定してください'
+  if (data.entry_price == null || data.entry_price < 0) return '購入価格は0以上を指定してください'
+  return null
+}
+
+export async function createTrade(data: CreateTradeInput): Promise<TradeActionResult> {
+  const validationError = validateTradeInput(data)
+  if (validationError) {
+    return { success: false, error: validationError }
+  }
+
+  const pnl = calculatePnl(data.exit_price, data.entry_price, data.quantity)
+
+  const { error } = await supabase.from('trades').insert({
+    trade_date: data.trade_date,
+    trade_type: data.trade_type,
+    strike_price: data.strike_price,
+    expiry_date: data.expiry_date,
+    quantity: data.quantity,
+    entry_price: data.entry_price,
+    exit_price: data.exit_price,
+    exit_date: data.exit_date,
+    pnl,
+    iv_at_entry: data.iv_at_entry,
+    memo: data.memo,
+    status: data.exit_price !== null ? 'closed' : 'open',
+    defeat_tags: null,
+    user_id: null,
+  })
+
+  if (error) {
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/trades')
+  return { success: true }
+}
+
+export async function updateTrade(id: string, data: UpdateTradeInput): Promise<TradeActionResult> {
+  if (!id) {
+    return { success: false, error: '取引IDが指定されていません' }
+  }
+
+  const validationError = validateTradeInput(data)
+  if (validationError) {
+    return { success: false, error: validationError }
+  }
+
+  const pnl = calculatePnl(data.exit_price, data.entry_price, data.quantity)
+
+  const { error } = await supabase
+    .from('trades')
+    .update({
+      trade_date: data.trade_date,
+      trade_type: data.trade_type,
+      strike_price: data.strike_price,
+      expiry_date: data.expiry_date,
+      quantity: data.quantity,
+      entry_price: data.entry_price,
+      exit_price: data.exit_price,
+      exit_date: data.exit_date,
+      pnl,
+      iv_at_entry: data.iv_at_entry,
+      memo: data.memo,
+      status: data.exit_price !== null ? 'closed' : 'open',
+    })
+    .eq('id', id)
+
+  if (error) {
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/trades')
+  revalidatePath(`/trades/${id}`)
+  return { success: true }
+}
+
+export async function deleteTrade(id: string): Promise<TradeActionResult> {
+  if (!id) {
+    return { success: false, error: '取引IDが指定されていません' }
+  }
+
+  const { error } = await supabase.from('trades').delete().eq('id', id)
+
+  if (error) {
+    return { success: false, error: error.message }
+  }
+
+  revalidatePath('/trades')
+  return { success: true }
+}

--- a/src/app/trades/[id]/DeleteButton.tsx
+++ b/src/app/trades/[id]/DeleteButton.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
-import { supabase } from '@/lib/supabase'
+import { deleteTrade } from '@/app/actions/trades'
 
 export default function DeleteButton({ tradeId }: { tradeId: string }) {
   const router = useRouter()
@@ -12,10 +12,10 @@ export default function DeleteButton({ tradeId }: { tradeId: string }) {
     if (!confirm('この取引記録を削除しますか？この操作は元に戻せません。')) return
 
     setLoading(true)
-    const { error } = await supabase.from('trades').delete().eq('id', tradeId)
+    const result = await deleteTrade(tradeId)
 
-    if (error) {
-      alert('削除に失敗しました: ' + error.message)
+    if (!result.success) {
+      alert('削除に失敗しました: ' + result.error)
       setLoading(false)
       return
     }

--- a/src/app/trades/[id]/edit/page.tsx
+++ b/src/app/trades/[id]/edit/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { supabase } from '@/lib/supabase'
-import { calculatePnl } from '@/lib/trade'
+import { updateTrade } from '@/app/actions/trades'
 import type { Trade } from '@/types/database'
 
 const inputClass =
@@ -53,34 +53,24 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
     const form = e.currentTarget
     const data = new FormData(form)
 
-    const entryPrice = parseFloat(data.get('entry_price') as string)
     const exitPriceRaw = data.get('exit_price') as string
-    const exitPrice = exitPriceRaw ? parseFloat(exitPriceRaw) : null
     const exitDateRaw = data.get('exit_date') as string
-    const quantity = parseInt(data.get('quantity') as string)
 
-    const pnl = calculatePnl(exitPrice, entryPrice, quantity)
+    const result = await updateTrade(tradeId, {
+      trade_date: data.get('trade_date') as string,
+      trade_type: isSettle ? trade.trade_type : tradeType,
+      strike_price: parseInt(data.get('strike_price') as string),
+      expiry_date: data.get('expiry_date') as string,
+      quantity: parseInt(data.get('quantity') as string),
+      entry_price: parseFloat(data.get('entry_price') as string),
+      exit_price: exitPriceRaw ? parseFloat(exitPriceRaw) : null,
+      exit_date: exitDateRaw || null,
+      iv_at_entry: data.get('iv_at_entry') ? parseFloat(data.get('iv_at_entry') as string) : null,
+      memo: (data.get('memo') as string) || null,
+    })
 
-    const { error: updateError } = await supabase
-      .from('trades')
-      .update({
-        trade_date: data.get('trade_date') as string,
-        trade_type: isSettle ? trade.trade_type : tradeType,
-        strike_price: parseInt(data.get('strike_price') as string),
-        expiry_date: data.get('expiry_date') as string,
-        quantity,
-        entry_price: entryPrice,
-        exit_price: exitPrice,
-        exit_date: exitDateRaw || null,
-        pnl,
-        iv_at_entry: data.get('iv_at_entry') ? parseFloat(data.get('iv_at_entry') as string) : null,
-        memo: (data.get('memo') as string) || null,
-        status: exitPrice !== null ? 'closed' : 'open',
-      })
-      .eq('id', tradeId)
-
-    if (updateError) {
-      setError(updateError.message)
+    if (!result.success) {
+      setError(result.error)
       setLoading(false)
       return
     }

--- a/src/app/trades/new/page.tsx
+++ b/src/app/trades/new/page.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { supabase } from '@/lib/supabase'
-import { calculatePnl } from '@/lib/trade'
+import { createTrade } from '@/app/actions/trades'
 
 const inputClass =
   'w-full bg-slate-800 border border-slate-700 text-slate-100 rounded-xl px-3 py-2.5 text-sm placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
@@ -25,38 +24,30 @@ export default function NewTradePage() {
     const form = e.currentTarget
     const data = new FormData(form)
 
-    const entryPrice = parseFloat(data.get('entry_price') as string)
     const exitPriceRaw = data.get('exit_price') as string
-    const exitPrice = exitPriceRaw ? parseFloat(exitPriceRaw) : null
     const exitDateRaw = data.get('exit_date') as string
-    const quantity = parseInt(data.get('quantity') as string)
 
-    const pnl = calculatePnl(exitPrice, entryPrice, quantity)
-
-    const { error: insertError } = await supabase.from('trades').insert({
+    const result = await createTrade({
       trade_date: data.get('trade_date') as string,
       trade_type: tradeType,
       strike_price: parseInt(data.get('strike_price') as string),
       expiry_date: data.get('expiry_date') as string,
-      quantity,
-      entry_price: entryPrice,
-      exit_price: exitPrice,
+      quantity: parseInt(data.get('quantity') as string),
+      entry_price: parseFloat(data.get('entry_price') as string),
+      exit_price: exitPriceRaw ? parseFloat(exitPriceRaw) : null,
       exit_date: exitDateRaw || null,
-      pnl,
       iv_at_entry: data.get('iv_at_entry') ? parseFloat(data.get('iv_at_entry') as string) : null,
       memo: (data.get('memo') as string) || null,
-      status: exitPrice !== null ? 'closed' : 'open',
-      defeat_tags: null,
-      user_id: null,
     })
 
-    if (insertError) {
-      setError(insertError.message)
+    if (!result.success) {
+      setError(result.error)
       setLoading(false)
       return
     }
 
     router.push('/trades')
+    router.refresh()
   }
 
   return (

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Related Issue
Closes #6

## Summary
- `src/app/actions/trades.ts` を新規作成（`'use server'`）
- `createTrade`, `updateTrade`, `deleteTrade` の3つのServer Actionsを実装
- バリデーションロジックをサーバー側に集約
- `revalidatePath` によるキャッシュ更新
- 3つのクライアントコンポーネントからServer Action呼び出しに変更

## Test plan
- 新規取引作成が正常に動作すること
- 取引編集が正常に動作すること
- 取引削除が正常に動作すること
- 一覧画面が操作後に即時更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)