### PR TITLE
feat: IVランク・IVパーセンタイルの計算ロジック実装

### DIFF
--- a/src/lib/iv-calculations.ts
+++ b/src/lib/iv-calculations.ts
@@ -1,0 +1,90 @@
+/**
+ * IVランク・IVパーセンタイルの計算ユーティリティ
+ *
+ * エントリー判断の定量的指標として使用する。
+ * - IVランク: 過去1年の範囲における現在IVの位置
+ * - IVパーセンタイル: 過去1年で現在IVより低かった日数の割合
+ */
+
+/**
+ * IVランクを計算する
+ * IVランク = (現在IV - 1年最低) / (1年最高 - 1年最低) × 100
+ *
+ * @param currentIv 現在のIV
+ * @param minIvYearly 過去1年の最低IV
+ * @param maxIvYearly 過去1年の最高IV
+ * @returns IVランク (0-100)
+ */
+export function calculateIvRank(
+  currentIv: number,
+  minIvYearly: number,
+  maxIvYearly: number
+): number {
+  // ゼロ除算防止: 最高と最低が同じ場合は50を返す
+  if (maxIvYearly === minIvYearly) {
+    return 50
+  }
+
+  const rank = ((currentIv - minIvYearly) / (maxIvYearly - minIvYearly)) * 100
+
+  // 結果を0-100にクランプ
+  return Math.min(100, Math.max(0, rank))
+}
+
+/**
+ * IVパーセンタイルを計算する
+ * IVパーセンタイル = 過去1年で現在IVより低かった日数 / 252 × 100
+ *
+ * @param currentIv 現在のIV
+ * @param historicalIvs 過去1年分のIV配列（252営業日分）
+ * @returns IVパーセンタイル (0-100)
+ */
+export function calculateIvPercentile(
+  currentIv: number,
+  historicalIvs: number[]
+): number {
+  if (historicalIvs.length === 0) {
+    return 50
+  }
+
+  const daysBelow = historicalIvs.filter((iv) => iv < currentIv).length
+  const percentile = (daysBelow / historicalIvs.length) * 100
+
+  // 結果を0-100にクランプ
+  return Math.min(100, Math.max(0, percentile))
+}
+
+/**
+ * IVランクに基づく色を返す
+ * - 0-25: 緑（買い好機） - IVが低い = オプション買いに有利
+ * - 25-75: 黄（中立）
+ * - 75-100: 赤（売り好機） - IVが高い = オプション売りに有利
+ *
+ * @param ivRank IVランク (0-100)
+ * @returns Tailwind CSSカラークラス名
+ */
+export function getIvRankColor(ivRank: number): string {
+  if (ivRank <= 25) {
+    return 'bg-emerald-500'
+  }
+  if (ivRank >= 75) {
+    return 'bg-red-500'
+  }
+  return 'bg-slate-500'
+}
+
+/**
+ * IVランクに基づくラベルを返す
+ *
+ * @param ivRank IVランク (0-100)
+ * @returns ラベル文字列
+ */
+export function getIvRankLabel(ivRank: number): string {
+  if (ivRank <= 25) {
+    return '買い好機'
+  }
+  if (ivRank >= 75) {
+    return '売り好機'
+  }
+  return '中立'
+}


### PR DESCRIPTION
## Related Issue
Closes #9

## Summary
- `calculateIvRank()`: IVランク計算（ゼロ除算防止、0-100クランプ）
- `calculateIvPercentile()`: IVパーセンタイル計算（任意日数対応）
- `getIvRankColor()`: Tailwind CSSカラークラス（0-25緑/25-75黄/75-100赤）
- `getIvRankLabel()`: ラベル（買い好機/中立/売り好機）

## Test plan
- IVランクが0-100の範囲内に収まること
- max === min の場合に50が返ること
- パーセンタイル計算が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)