### PR TITLE
feat: HV計算・IV/HV比・PCR指標の計算ユーティリティを実装

### DIFF
--- a/src/lib/hv-calculations.ts
+++ b/src/lib/hv-calculations.ts
@@ -1,0 +1,102 @@
+/**
+ * ヒストリカルボラティリティ（HV）計算ユーティリティ
+ *
+ * 計算式:
+ * - 対数リターン: ln(P[i] / P[i-1])
+ * - HV = 対数リターンの標準偏差 × √252（年率化）
+ * - IV/HV比 = 現在IV ÷ HV20
+ */
+
+/**
+ * ヒストリカルボラティリティを計算する
+ * @param prices 価格配列（時系列順、最新が末尾）
+ * @param period 期間（20 or 60）
+ * @returns HV（パーセンテージ）。計算不能の場合は null
+ */
+export function calculateHistoricalVolatility(
+  prices: number[],
+  period: number
+): number | null {
+  // 価格データが不足している場合
+  if (prices.length < 2 || period < 1) {
+    return null
+  }
+
+  // period+1 個の価格が必要（period個のリターンを計算するため）
+  if (prices.length < period + 1) {
+    return null
+  }
+
+  // 直近 period+1 個の価格を使用
+  const recentPrices = prices.slice(-(period + 1))
+
+  // 1. 対数リターン計算: ln(P[i] / P[i-1])
+  const logReturns: number[] = []
+  for (let i = 1; i < recentPrices.length; i++) {
+    if (recentPrices[i - 1] <= 0) {
+      return null // ゼロ以下の価格は不正
+    }
+    logReturns.push(Math.log(recentPrices[i] / recentPrices[i - 1]))
+  }
+
+  // 2. 標準偏差計算
+  const mean = logReturns.reduce((sum, r) => sum + r, 0) / logReturns.length
+  const variance =
+    logReturns.reduce((sum, r) => sum + (r - mean) ** 2, 0) /
+    (logReturns.length - 1) // 不偏分散
+  const stdDev = Math.sqrt(variance)
+
+  // 3. 年率化: × √252
+  const annualized = stdDev * Math.sqrt(252)
+
+  // 4. パーセンテージ化: × 100
+  return annualized * 100
+}
+
+/**
+ * IV/HV比を計算する
+ * @param currentIv 現在のインプライドボラティリティ（パーセンテージ）
+ * @param hv20 20日ヒストリカルボラティリティ（パーセンテージ）
+ * @returns IV/HV比。計算不能の場合は null
+ */
+export function calculateIvHvRatio(
+  currentIv: number,
+  hv20: number
+): number | null {
+  // ゼロ除算防止
+  if (hv20 === 0) {
+    return null
+  }
+  return currentIv / hv20
+}
+
+/**
+ * IV/HV比のシグナルラベルを返す
+ * @param ratio IV/HV比
+ * @returns シグナルラベル
+ */
+export function getIvHvSignal(
+  ratio: number
+): '買い好機' | '中立' | '売り好機' {
+  if (ratio < 1.0) {
+    return '買い好機'
+  }
+  if (ratio > 1.5) {
+    return '売り好機'
+  }
+  return '中立'
+}
+
+/**
+ * PCR（プット・コール・レシオ）のシグナルラベルを返す
+ * @param pcr プット出来高 ÷ コール出来高
+ * @returns シグナルラベル
+ */
+export function getPcrSignal(
+  pcr: number
+): '逆張り買いシグナル補強' | '中立' {
+  if (pcr > 1.2) {
+    return '逆張り買いシグナル補強'
+  }
+  return '中立'
+}

--- a/src/lib/jquants-data.ts
+++ b/src/lib/jquants-data.ts
@@ -1,0 +1,62 @@
+/**
+ * J-Quants APIからのデータ取得に関する型定義
+ *
+ * 実際のAPI呼び出しロジックは Issue #7 で実装予定。
+ * ここでは型定義のみを提供する。
+ */
+
+/**
+ * IV（インプライドボラティリティ）データ取得結果
+ */
+export interface FetchIVDataResult {
+  /** 日経225のATM IV（パーセンテージ） */
+  atmIv: number
+  /** 日経VI（ボラティリティインデックス） */
+  nikkeiVi: number
+  /** データ取得日 */
+  date: string
+}
+
+/**
+ * 価格データ取得結果
+ */
+export interface FetchPriceDataResult {
+  /** 日経225終値の配列（時系列順、最新が末尾） */
+  prices: number[]
+  /** データの開始日 */
+  startDate: string
+  /** データの終了日 */
+  endDate: string
+}
+
+/**
+ * PCR（プット・コール・レシオ）データ取得結果
+ */
+export interface FetchPCRDataResult {
+  /** プット出来高 */
+  putVolume: number
+  /** コール出来高 */
+  callVolume: number
+  /** PCR値（プット出来高 ÷ コール出来高） */
+  pcr: number
+  /** データ取得日 */
+  date: string
+}
+
+/**
+ * 補助指標の集約結果
+ */
+export interface MarketIndicators {
+  /** 20日ヒストリカルボラティリティ（パーセンテージ） */
+  hv20: number | null
+  /** 60日ヒストリカルボラティリティ（パーセンテージ） */
+  hv60: number | null
+  /** 現在のATM IV（パーセンテージ） */
+  atmIv: number | null
+  /** IV/HV比 */
+  ivHvRatio: number | null
+  /** 日経VI */
+  nikkeiVi: number | null
+  /** PCR値 */
+  pcr: number | null
+}


### PR DESCRIPTION
## Related Issue
Closes #10

## Summary
- `calculateHistoricalVolatility()`: 対数リターンの標準偏差×√252で年率HV算出
- `calculateIvHvRatio()`: IV/HV比計算（ゼロ除算防止）
- `getIvHvSignal()`: 1.0未満=買い好機、1.5超=売り好機
- `getPcrSignal()`: PCR 1.2超=逆張り買いシグナル補強
- J-Quants APIデータ型定義（FetchIVDataResult, FetchPriceDataResult等）

## Test plan
- HV20/HV60の計算精度確認
- 空配列・短配列時のエッジケースハンドリング
- IV/HV比のシグナル判定

🤖 Generated with [Claude Code](https://claude.com/claude-code)