### PR TITLE
feat: J-Quants API接続基盤と認証トークン管理を実装

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# J-Quants API
+J_QUANTS_MAIL_ADDRESS=your_email
+J_QUANTS_PASSWORD=your_password

--- a/src/app/api/auth/jquants/route.ts
+++ b/src/app/api/auth/jquants/route.ts
@@ -1,0 +1,131 @@
+/**
+ * J-Quants 認証エンドポイント
+ *
+ * POST: メールアドレス/パスワードで初期トークン取得 → Supabaseに保存
+ * GET: 現在のトークン状態を確認
+ */
+
+import { NextResponse } from 'next/server'
+import { getRefreshToken, getIdToken, JQuantsApiError } from '@/lib/jquants'
+import { saveTokens, getStoredTokens } from '@/lib/jquants-token'
+
+// リフレッシュトークンの有効期間（1週間）
+const REFRESH_TOKEN_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000
+// IDトークンの有効期間（24時間）
+const ID_TOKEN_LIFETIME_MS = 24 * 60 * 60 * 1000
+
+/**
+ * POST /api/auth/jquants
+ *
+ * リクエストボディ:
+ * - mailAddress: string
+ * - password: string
+ *
+ * メールアドレス/パスワードでJ-Quants APIに認証し、
+ * 取得したトークンをSupabaseに保存する。
+ */
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      mailAddress?: string
+      password?: string
+    }
+
+    const mailAddress = body.mailAddress || process.env.J_QUANTS_MAIL_ADDRESS
+    const password = body.password || process.env.J_QUANTS_PASSWORD
+
+    if (!mailAddress || !password) {
+      return NextResponse.json(
+        {
+          error:
+            'Mail address and password are required. Provide in request body or set J_QUANTS_MAIL_ADDRESS and J_QUANTS_PASSWORD environment variables.',
+        },
+        { status: 400 },
+      )
+    }
+
+    // リフレッシュトークンを取得
+    const refreshToken = await getRefreshToken(mailAddress, password)
+    const refreshTokenExpiresAt = new Date(
+      Date.now() + REFRESH_TOKEN_LIFETIME_MS,
+    )
+
+    // IDトークンを取得
+    const idToken = await getIdToken(refreshToken)
+    const idTokenExpiresAt = new Date(Date.now() + ID_TOKEN_LIFETIME_MS)
+
+    // Supabaseに保存
+    await saveTokens(
+      refreshToken,
+      idToken,
+      refreshTokenExpiresAt,
+      idTokenExpiresAt,
+    )
+
+    return NextResponse.json({
+      success: true,
+      message: 'J-Quants authentication successful. Tokens saved.',
+      refreshTokenExpiresAt: refreshTokenExpiresAt.toISOString(),
+      idTokenExpiresAt: idTokenExpiresAt.toISOString(),
+    })
+  } catch (error) {
+    if (error instanceof JQuantsApiError) {
+      return NextResponse.json(
+        {
+          error: `J-Quants API error: ${error.message}`,
+          status: error.status,
+          endpoint: error.endpoint,
+        },
+        { status: error.status },
+      )
+    }
+
+    const message =
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+/**
+ * GET /api/auth/jquants
+ *
+ * 現在のトークン状態を返す。
+ * トークンの有効期限と、期限切れかどうかを確認できる。
+ */
+export async function GET() {
+  try {
+    const stored = await getStoredTokens()
+
+    if (!stored) {
+      return NextResponse.json({
+        authenticated: false,
+        message:
+          'No tokens found. POST to this endpoint to authenticate.',
+      })
+    }
+
+    const now = new Date()
+    const refreshExpiry = new Date(stored.refresh_token_expires_at)
+    const idExpiry = stored.id_token_expires_at
+      ? new Date(stored.id_token_expires_at)
+      : null
+
+    return NextResponse.json({
+      authenticated: true,
+      refreshToken: {
+        expiresAt: stored.refresh_token_expires_at,
+        isExpired: now >= refreshExpiry,
+      },
+      idToken: {
+        exists: !!stored.id_token,
+        expiresAt: stored.id_token_expires_at,
+        isExpired: idExpiry ? now >= idExpiry : true,
+      },
+      updatedAt: stored.updated_at,
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/lib/jquants-token.ts
+++ b/src/lib/jquants-token.ts
@@ -1,0 +1,197 @@
+/**
+ * J-Quants トークン管理ユーティリティ
+ *
+ * Supabaseにトークンを永続化し、有効期限に基づいた自動更新を行う。
+ * - リフレッシュトークン有効期限: 1週間
+ * - IDトークン有効期限: 24時間
+ */
+
+import { supabase } from './supabase'
+import { getIdToken, getRefreshToken } from './jquants'
+
+// --- 型定義 ---
+
+export interface JQuantsTokenRecord {
+  id: string
+  refresh_token: string
+  id_token: string | null
+  refresh_token_expires_at: string
+  id_token_expires_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+// IDトークンの有効期限バッファ（5分前に更新）
+const ID_TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000
+// リフレッシュトークンの有効期限バッファ（1時間前に更新）
+const REFRESH_TOKEN_EXPIRY_BUFFER_MS = 60 * 60 * 1000
+// リフレッシュトークンの有効期間（1週間）
+const REFRESH_TOKEN_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000
+// IDトークンの有効期間（24時間）
+const ID_TOKEN_LIFETIME_MS = 24 * 60 * 60 * 1000
+
+// --- トークン永続化 ---
+
+/**
+ * トークンをSupabaseに保存する
+ *
+ * 既存レコードがある場合はupdateし、なければinsertする（シングルテナント想定）。
+ */
+export async function saveTokens(
+  refreshToken: string,
+  idToken: string | null,
+  refreshTokenExpiresAt: Date,
+  idTokenExpiresAt: Date | null,
+): Promise<void> {
+  // 既存レコードを取得
+  const { data: existing } = await supabase
+    .from('j_quants_tokens')
+    .select('id')
+    .limit(1)
+    .single()
+
+  if (existing) {
+    // 既存レコードを更新
+    const { error } = await supabase
+      .from('j_quants_tokens')
+      .update({
+        refresh_token: refreshToken,
+        id_token: idToken,
+        refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+        id_token_expires_at: idTokenExpiresAt?.toISOString() ?? null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', existing.id)
+
+    if (error) {
+      throw new Error(`Failed to update tokens: ${error.message}`)
+    }
+  } else {
+    // 新規レコードを作成
+    const { error } = await supabase.from('j_quants_tokens').insert({
+      refresh_token: refreshToken,
+      id_token: idToken,
+      refresh_token_expires_at: refreshTokenExpiresAt.toISOString(),
+      id_token_expires_at: idTokenExpiresAt?.toISOString() ?? null,
+    })
+
+    if (error) {
+      throw new Error(`Failed to save tokens: ${error.message}`)
+    }
+  }
+}
+
+/**
+ * Supabaseからトークンレコードを取得する
+ */
+export async function getStoredTokens(): Promise<JQuantsTokenRecord | null> {
+  const { data, error } = await supabase
+    .from('j_quants_tokens')
+    .select('*')
+    .limit(1)
+    .single()
+
+  if (error || !data) {
+    return null
+  }
+
+  return data as JQuantsTokenRecord
+}
+
+// --- トークン有効性チェック ---
+
+function isTokenExpired(expiresAt: string | null, bufferMs: number): boolean {
+  if (!expiresAt) return true
+  const expiryTime = new Date(expiresAt).getTime()
+  return Date.now() >= expiryTime - bufferMs
+}
+
+// --- 自動更新付きトークン取得 ---
+
+/**
+ * 有効なIDトークンを取得する
+ *
+ * 1. Supabaseに保存されたトークンを確認
+ * 2. IDトークンが有効ならそのまま返す
+ * 3. IDトークンが期限切れならリフレッシュトークンで再取得
+ * 4. リフレッシュトークンも期限切れならメールアドレス/パスワードで再認証
+ *
+ * @returns 有効なIDトークン
+ * @throws リフレッシュトークンが期限切れかつ認証情報が未設定の場合
+ */
+export async function getValidIdToken(): Promise<string> {
+  const stored = await getStoredTokens()
+
+  // 保存されたトークンがない場合 → 初期認証が必要
+  if (!stored) {
+    return await reauthenticateAndSave()
+  }
+
+  // IDトークンが有効ならそのまま返す
+  if (
+    stored.id_token &&
+    !isTokenExpired(stored.id_token_expires_at, ID_TOKEN_EXPIRY_BUFFER_MS)
+  ) {
+    return stored.id_token
+  }
+
+  // リフレッシュトークンが有効 → IDトークンを再取得
+  if (
+    !isTokenExpired(
+      stored.refresh_token_expires_at,
+      REFRESH_TOKEN_EXPIRY_BUFFER_MS,
+    )
+  ) {
+    return await refreshIdTokenAndSave(stored.refresh_token)
+  }
+
+  // リフレッシュトークンも期限切れ → メールアドレス/パスワードで再認証
+  return await reauthenticateAndSave()
+}
+
+/**
+ * リフレッシュトークンを使ってIDトークンを再取得し、Supabaseに保存する
+ */
+async function refreshIdTokenAndSave(refreshToken: string): Promise<string> {
+  const idToken = await getIdToken(refreshToken)
+  const idTokenExpiresAt = new Date(Date.now() + ID_TOKEN_LIFETIME_MS)
+
+  // リフレッシュトークンの有効期限は変わらないので、既存の値を保持
+  const stored = await getStoredTokens()
+  const refreshTokenExpiresAt = stored
+    ? new Date(stored.refresh_token_expires_at)
+    : new Date(Date.now() + REFRESH_TOKEN_LIFETIME_MS)
+
+  await saveTokens(refreshToken, idToken, refreshTokenExpiresAt, idTokenExpiresAt)
+
+  return idToken
+}
+
+/**
+ * メールアドレス/パスワードで再認証し、トークンをSupabaseに保存する
+ */
+async function reauthenticateAndSave(): Promise<string> {
+  const mailAddress = process.env.J_QUANTS_MAIL_ADDRESS
+  const password = process.env.J_QUANTS_PASSWORD
+
+  if (!mailAddress || !password) {
+    throw new Error(
+      'J-Quants credentials not configured. Set J_QUANTS_MAIL_ADDRESS and J_QUANTS_PASSWORD environment variables.',
+    )
+  }
+
+  // リフレッシュトークンを取得
+  const refreshToken = await getRefreshToken(mailAddress, password)
+  const refreshTokenExpiresAt = new Date(
+    Date.now() + REFRESH_TOKEN_LIFETIME_MS,
+  )
+
+  // IDトークンを取得
+  const idToken = await getIdToken(refreshToken)
+  const idTokenExpiresAt = new Date(Date.now() + ID_TOKEN_LIFETIME_MS)
+
+  // 保存
+  await saveTokens(refreshToken, idToken, refreshTokenExpiresAt, idTokenExpiresAt)
+
+  return idToken
+}

--- a/src/lib/jquants.ts
+++ b/src/lib/jquants.ts
@@ -1,0 +1,259 @@
+/**
+ * J-Quants API クライアント
+ *
+ * JPX公式のJ-Quants API v3に接続し、オプション・先物価格データを取得する。
+ * 認証トークンの自動管理機能を含む。
+ *
+ * @see https://jpx.gitbook.io/j-quants-api
+ */
+
+const JQUANTS_API_BASE = 'https://api.jquants.com/v1'
+
+// --- API エンドポイント定義 ---
+const ENDPOINTS = {
+  // 認証
+  TOKEN_AUTH_USER: '/token/auth_user',
+  TOKEN_AUTH_REFRESH: '/token/auth_refresh',
+  // マーケットデータ
+  OPTION_INDEX_OPTION: '/option/index_option',
+  DERIVATIVES_FUTURES: '/derivatives/futures',
+  INDICES: '/indices',
+} as const
+
+// --- 型定義 ---
+
+export interface JQuantsAuthResponse {
+  refreshToken: string
+}
+
+export interface JQuantsRefreshResponse {
+  idToken: string
+}
+
+export interface JQuantsOptionPrice {
+  Date: string
+  Code: string
+  WholeDayOpen: number | null
+  WholeDayHigh: number | null
+  WholeDayLow: number | null
+  WholeDayClose: number | null
+  Volume: number | null
+  OpenInterest: number | null
+  TurnoverValue: number | null
+  ContractMonth: string
+  StrikePrice: number
+  PutCallDivision: string // "1" = Put, "2" = Call
+  ImpliedVolatility: number | null
+  UnderlyingPrice: number | null
+  TheoreticalPrice: number | null
+}
+
+export interface JQuantsOptionPricesResponse {
+  index_option: JQuantsOptionPrice[]
+}
+
+export interface JQuantsFuturesPrice {
+  Date: string
+  Code: string
+  WholeDayOpen: number | null
+  WholeDayHigh: number | null
+  WholeDayLow: number | null
+  WholeDayClose: number | null
+  Volume: number | null
+  OpenInterest: number | null
+  TurnoverValue: number | null
+  ContractMonth: string
+}
+
+export interface JQuantsFuturesPricesResponse {
+  futures: JQuantsFuturesPrice[]
+}
+
+export interface JQuantsIndicesResponse {
+  indices: {
+    Date: string
+    Code: string
+    Open: number | null
+    High: number | null
+    Low: number | null
+    Close: number | null
+  }[]
+}
+
+export class JQuantsApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public endpoint: string,
+  ) {
+    super(message)
+    this.name = 'JQuantsApiError'
+  }
+}
+
+// --- 認証関連 ---
+
+/**
+ * メールアドレス/パスワードでリフレッシュトークンを取得する
+ */
+export async function getRefreshToken(
+  mailAddress: string,
+  password: string,
+): Promise<string> {
+  const response = await fetch(
+    `${JQUANTS_API_BASE}${ENDPOINTS.TOKEN_AUTH_USER}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mailaddress: mailAddress,
+        password: password,
+      }),
+    },
+  )
+
+  if (!response.ok) {
+    throw new JQuantsApiError(
+      `Failed to get refresh token: ${response.statusText}`,
+      response.status,
+      ENDPOINTS.TOKEN_AUTH_USER,
+    )
+  }
+
+  const data = (await response.json()) as JQuantsAuthResponse
+  return data.refreshToken
+}
+
+/**
+ * リフレッシュトークンからIDトークン（アクセストークン）を取得する
+ */
+export async function getIdToken(refreshToken: string): Promise<string> {
+  const params = new URLSearchParams({ refreshtoken: refreshToken })
+  const response = await fetch(
+    `${JQUANTS_API_BASE}${ENDPOINTS.TOKEN_AUTH_REFRESH}?${params}`,
+    {
+      method: 'POST',
+    },
+  )
+
+  if (!response.ok) {
+    throw new JQuantsApiError(
+      `Failed to get ID token: ${response.statusText}`,
+      response.status,
+      ENDPOINTS.TOKEN_AUTH_REFRESH,
+    )
+  }
+
+  const data = (await response.json()) as JQuantsRefreshResponse
+  return data.idToken
+}
+
+// --- 認証付きAPI呼び出し ---
+
+/**
+ * 認証付きでJ-Quants APIを呼び出す
+ *
+ * @param endpoint - APIエンドポイントパス
+ * @param idToken - IDトークン
+ * @param params - クエリパラメータ
+ */
+export async function fetchWithAuth<T>(
+  endpoint: string,
+  idToken: string,
+  params?: Record<string, string>,
+): Promise<T> {
+  const url = new URL(`${JQUANTS_API_BASE}${endpoint}`)
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.set(key, value)
+    })
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  })
+
+  if (!response.ok) {
+    throw new JQuantsApiError(
+      `API request failed: ${response.statusText}`,
+      response.status,
+      endpoint,
+    )
+  }
+
+  return (await response.json()) as T
+}
+
+// --- データ取得ヘルパー ---
+
+/**
+ * オプション価格を取得する
+ *
+ * @param idToken - IDトークン
+ * @param date - 取得日（YYYY-MM-DD形式）。省略時は直近営業日
+ */
+export async function fetchOptionPrices(
+  idToken: string,
+  date?: string,
+): Promise<JQuantsOptionPrice[]> {
+  const params: Record<string, string> = {}
+  if (date) {
+    params.date = date
+  }
+
+  const data = await fetchWithAuth<JQuantsOptionPricesResponse>(
+    ENDPOINTS.OPTION_INDEX_OPTION,
+    idToken,
+    params,
+  )
+  return data.index_option ?? []
+}
+
+/**
+ * 先物価格を取得する
+ *
+ * @param idToken - IDトークン
+ * @param date - 取得日（YYYY-MM-DD形式）。省略時は直近営業日
+ */
+export async function fetchFuturesPrices(
+  idToken: string,
+  date?: string,
+): Promise<JQuantsFuturesPrice[]> {
+  const params: Record<string, string> = {}
+  if (date) {
+    params.date = date
+  }
+
+  const data = await fetchWithAuth<JQuantsFuturesPricesResponse>(
+    ENDPOINTS.DERIVATIVES_FUTURES,
+    idToken,
+    params,
+  )
+  return data.futures ?? []
+}
+
+/**
+ * 指数データ（日経平均・日経VIなど）を取得する
+ *
+ * @param idToken - IDトークン
+ * @param code - 指数コード（例: "0000" = 日経225）
+ * @param date - 取得日（YYYY-MM-DD形式）
+ */
+export async function fetchIndices(
+  idToken: string,
+  code?: string,
+  date?: string,
+): Promise<JQuantsIndicesResponse['indices']> {
+  const params: Record<string, string> = {}
+  if (code) params.code = code
+  if (date) params.date = date
+
+  const data = await fetchWithAuth<JQuantsIndicesResponse>(
+    ENDPOINTS.INDICES,
+    idToken,
+    params,
+  )
+  return data.indices ?? []
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -21,6 +21,16 @@ export interface Trade {
   defeat_tags: string[] | null
 }
 
+export interface JQuantsToken {
+  id: string
+  refresh_token: string
+  id_token: string | null
+  refresh_token_expires_at: string
+  id_token_expires_at: string | null
+  created_at: string
+  updated_at: string
+}
+
 export type Database = {
   public: {
     Tables: {
@@ -28,6 +38,12 @@ export type Database = {
         Row: Trade
         Insert: Omit<Trade, 'id' | 'created_at' | 'updated_at'>
         Update: Partial<Omit<Trade, 'id' | 'created_at' | 'updated_at'>>
+        Relationships: []
+      }
+      j_quants_tokens: {
+        Row: JQuantsToken
+        Insert: Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>
+        Update: Partial<Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>>
         Relationships: []
       }
     }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -41,3 +41,21 @@ create index if not exists trades_user_id_idx on trades (user_id);
 alter table trades enable row level security;
 -- Phase 4でのポリシー追加例:
 -- create policy "Users can only see own trades" on trades for select using (auth.uid() = user_id);
+
+-- =============================================
+-- J-Quants API トークン管理テーブル
+-- =============================================
+create table if not exists j_quants_tokens (
+  id uuid primary key default gen_random_uuid(),
+  refresh_token text not null,
+  id_token text,
+  refresh_token_expires_at timestamptz not null,
+  id_token_expires_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- updated_at を自動更新するトリガー
+create trigger j_quants_tokens_updated_at
+  before update on j_quants_tokens
+  for each row execute function update_updated_at();


### PR DESCRIPTION
## Related Issue
Closes #7

## Summary
- J-Quants API v3クライアント（認証・オプション/先物/指数データ取得）
- Supabaseベースのトークン永続化と自動更新（リフレッシュトークン1週間/IDトークン24時間）
- 初期認証・状態確認用APIエンドポイント（POST/GET /api/auth/jquants）
- `j_quants_tokens` テーブル定義をschema.sqlに追加
- 環境変数テンプレート更新

## Test plan
- Supabaseに `j_quants_tokens` テーブル作成後、POST /api/auth/jquants で初期トークン取得
- GET /api/auth/jquants でトークン状態確認
- トークン期限切れ時の自動更新動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)