### PR TITLE
feat: BS Merton版Greeks自動計算と取引フォーム統合を実装

### DIFF
--- a/src/app/actions/trades.ts
+++ b/src/app/actions/trades.ts
@@ -20,6 +20,10 @@ interface CreateTradeInput {
   exit_date: string | null
   iv_at_entry: number | null
   memo: string | null
+  entry_delta: number | null
+  entry_gamma: number | null
+  entry_theta: number | null
+  entry_vega: number | null
 }
 
 interface UpdateTradeInput {
@@ -68,6 +72,10 @@ export async function createTrade(data: CreateTradeInput): Promise<TradeActionRe
     status: data.exit_price !== null ? 'closed' : 'open',
     defeat_tags: null,
     user_id: null,
+    entry_delta: data.entry_delta,
+    entry_gamma: data.entry_gamma,
+    entry_theta: data.entry_theta,
+    entry_vega: data.entry_vega,
   })
 
   if (error) {

--- a/src/app/trades/new/page.tsx
+++ b/src/app/trades/new/page.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createTrade } from '@/app/actions/trades'
+import { calculateGreeks, type Greeks } from '@/lib/greeks'
+import type { BSInputs } from '@/lib/black-scholes'
 
 const inputClass =
   'w-full bg-slate-800 border border-slate-700 text-slate-100 rounded-xl px-3 py-2.5 text-sm placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
@@ -15,6 +17,57 @@ export default function NewTradePage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [tradeType, setTradeType] = useState<'call' | 'put'>('call')
+
+  // Greeks計算用の入力状態
+  const [spotPrice, setSpotPrice] = useState<string>('')
+  const [strikePrice, setStrikePrice] = useState<string>('')
+  const [ivAtEntry, setIvAtEntry] = useState<string>('')
+  const [expiryDate, setExpiryDate] = useState<string>('')
+  const [greeks, setGreeks] = useState<Greeks | null>(null)
+
+  // Greeks自動計算
+  const computeGreeks = useCallback(() => {
+    const spot = parseFloat(spotPrice)
+    const strike = parseFloat(strikePrice)
+    const iv = parseFloat(ivAtEntry)
+
+    if (!spot || !strike || !iv || !expiryDate) {
+      setGreeks(null)
+      return
+    }
+
+    // 満期までの年数を計算
+    const now = new Date()
+    const expiry = new Date(expiryDate)
+    const diffMs = expiry.getTime() - now.getTime()
+    const timeToExpiry = diffMs / (1000 * 60 * 60 * 24 * 365)
+
+    if (timeToExpiry <= 0) {
+      setGreeks(null)
+      return
+    }
+
+    const inputs: BSInputs = {
+      spot,
+      strike,
+      timeToExpiry,
+      volatility: iv / 100, // %から小数に変換
+      riskFreeRate: 0.001,
+      dividendYield: 0.02,
+      optionType: tradeType,
+    }
+
+    try {
+      const result = calculateGreeks(inputs)
+      setGreeks(result)
+    } catch {
+      setGreeks(null)
+    }
+  }, [spotPrice, strikePrice, ivAtEntry, expiryDate, tradeType])
+
+  useEffect(() => {
+    computeGreeks()
+  }, [computeGreeks])
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -38,6 +91,10 @@ export default function NewTradePage() {
       exit_date: exitDateRaw || null,
       iv_at_entry: data.get('iv_at_entry') ? parseFloat(data.get('iv_at_entry') as string) : null,
       memo: (data.get('memo') as string) || null,
+      entry_delta: greeks?.delta ?? null,
+      entry_gamma: greeks?.gamma ?? null,
+      entry_theta: greeks?.theta ?? null,
+      entry_vega: greeks?.vega ?? null,
     })
 
     if (!result.success) {
@@ -104,6 +161,8 @@ export default function NewTradePage() {
                   name="expiry_date"
                   type="date"
                   required
+                  value={expiryDate}
+                  onChange={(e) => setExpiryDate(e.target.value)}
                   className={inputClass}
                 />
               </div>
@@ -117,6 +176,8 @@ export default function NewTradePage() {
                   type="number"
                   required
                   placeholder="39000"
+                  value={strikePrice}
+                  onChange={(e) => setStrikePrice(e.target.value)}
                   className={inputClass}
                 />
               </div>
@@ -156,11 +217,25 @@ export default function NewTradePage() {
                   type="number"
                   step="0.01"
                   placeholder="18.5"
+                  value={ivAtEntry}
+                  onChange={(e) => setIvAtEntry(e.target.value)}
                   className={inputClass}
                 />
               </div>
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className={labelClass}>先物価格（原資産）</label>
+                <input
+                  name="spot_price"
+                  type="number"
+                  step="0.01"
+                  placeholder="38500"
+                  value={spotPrice}
+                  onChange={(e) => setSpotPrice(e.target.value)}
+                  className={inputClass}
+                />
+              </div>
               <div>
                 <label className={labelClass}>決済価格（任意）</label>
                 <input
@@ -171,6 +246,8 @@ export default function NewTradePage() {
                   className={inputClass}
                 />
               </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>決済日（任意）</label>
                 <input
@@ -181,6 +258,44 @@ export default function NewTradePage() {
               </div>
             </div>
           </div>
+
+          {/* Section: Greeks（自動計算） */}
+          {greeks && (
+            <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
+              <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">
+                Greeks（BS Merton版・自動計算）
+              </h2>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-slate-500 mb-1">Delta</div>
+                  <div className="text-lg font-mono font-semibold text-slate-100">
+                    {greeks.delta >= 0 ? '+' : ''}{greeks.delta.toFixed(4)}
+                  </div>
+                </div>
+                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-slate-500 mb-1">Gamma</div>
+                  <div className="text-lg font-mono font-semibold text-slate-100">
+                    {greeks.gamma.toFixed(6)}
+                  </div>
+                </div>
+                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-slate-500 mb-1">Theta</div>
+                  <div className="text-lg font-mono font-semibold text-slate-100">
+                    {greeks.theta >= 0 ? '+' : ''}{greeks.theta.toFixed(2)}
+                  </div>
+                </div>
+                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
+                  <div className="text-xs text-slate-500 mb-1">Vega</div>
+                  <div className="text-lg font-mono font-semibold text-slate-100">
+                    {greeks.vega.toFixed(2)}
+                  </div>
+                </div>
+              </div>
+              <p className="text-xs text-slate-600">
+                r=0.1%, q=2.0% で計算。Theta は1日あたり、Vega は IV 1%変化あたりの値。
+              </p>
+            </div>
+          )}
 
           {/* Section: メモ */}
           <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">

--- a/src/lib/black-scholes.ts
+++ b/src/lib/black-scholes.ts
@@ -1,0 +1,139 @@
+/**
+ * Black-Scholes Merton (配当調整版) オプション価格計算
+ */
+
+/**
+ * 正規分布CDF（Abramowitz and Stegun 近似）
+ * 精度: 最大誤差 ~1.5e-7
+ */
+export function normalCDF(x: number): number {
+  if (x < -8) return 0
+  if (x > 8) return 1
+
+  const a1 = 0.254829592
+  const a2 = -0.284496736
+  const a3 = 1.421413741
+  const a4 = -1.453152027
+  const a5 = 1.061405429
+  const p = 0.3275911
+
+  const sign = x < 0 ? -1 : 1
+  const absX = Math.abs(x)
+  const t = 1.0 / (1.0 + p * absX)
+  const t2 = t * t
+  const t3 = t2 * t
+  const t4 = t3 * t
+  const t5 = t4 * t
+
+  const y = 1.0 - (a1 * t + a2 * t2 + a3 * t3 + a4 * t4 + a5 * t5) * Math.exp(-absX * absX / 2)
+
+  return 0.5 * (1.0 + sign * y)
+}
+
+/**
+ * 正規分布PDF
+ */
+export function normalPDF(x: number): number {
+  return Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI)
+}
+
+export interface BSInputs {
+  spot: number          // 先物価格（原資産）
+  strike: number        // 権利行使価格
+  timeToExpiry: number  // 満期までの年数
+  volatility: number    // IV（小数、例: 0.20 = 20%）
+  riskFreeRate: number  // 無リスク金利（デフォルト0.001）
+  dividendYield: number // 配当利回り（デフォルト0.02）
+  optionType: 'call' | 'put'
+}
+
+/**
+ * d1, d2 パラメータ計算
+ */
+export function calculateD1D2(inputs: BSInputs): { d1: number; d2: number } {
+  const { spot, strike, timeToExpiry, volatility, riskFreeRate, dividendYield } = inputs
+  const sqrtT = Math.sqrt(timeToExpiry)
+
+  const d1 =
+    (Math.log(spot / strike) + (riskFreeRate - dividendYield + 0.5 * volatility * volatility) * timeToExpiry) /
+    (volatility * sqrtT)
+
+  const d2 = d1 - volatility * sqrtT
+
+  return { d1, d2 }
+}
+
+/**
+ * BS Merton版 オプション価格計算
+ */
+export function calculateBSPrice(inputs: BSInputs): number {
+  const { spot, strike, timeToExpiry, riskFreeRate, dividendYield, optionType } = inputs
+
+  if (timeToExpiry <= 0) {
+    // 満期時はイントリンシックバリュー
+    if (optionType === 'call') {
+      return Math.max(spot - strike, 0)
+    } else {
+      return Math.max(strike - spot, 0)
+    }
+  }
+
+  const { d1, d2 } = calculateD1D2(inputs)
+
+  const discountDividend = Math.exp(-dividendYield * timeToExpiry)
+  const discountRate = Math.exp(-riskFreeRate * timeToExpiry)
+
+  if (optionType === 'call') {
+    return spot * discountDividend * normalCDF(d1) - strike * discountRate * normalCDF(d2)
+  } else {
+    return strike * discountRate * normalCDF(-d2) - spot * discountDividend * normalCDF(-d1)
+  }
+}
+
+/**
+ * IV逆算（Newton-Raphson法）
+ * @param marketPrice 市場価格
+ * @param inputs volatilityを除いたBS入力パラメータ
+ * @returns 推定IV（小数）。収束しない場合は null
+ */
+export function calculateImpliedVolatility(
+  marketPrice: number,
+  inputs: Omit<BSInputs, 'volatility'>
+): number | null {
+  const MAX_ITERATIONS = 100
+  const PRECISION = 1e-8
+
+  let sigma = 0.20 // 初期値20%
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    const fullInputs: BSInputs = { ...inputs, volatility: sigma }
+    const price = calculateBSPrice(fullInputs)
+    const diff = price - marketPrice
+
+    if (Math.abs(diff) < PRECISION) {
+      return sigma
+    }
+
+    // Vega（σ微分）を計算
+    const { d1 } = calculateD1D2(fullInputs)
+    const sqrtT = Math.sqrt(inputs.timeToExpiry)
+    const discountDividend = Math.exp(-inputs.dividendYield * inputs.timeToExpiry)
+    const vega = inputs.spot * discountDividend * normalPDF(d1) * sqrtT
+
+    if (vega < 1e-12) {
+      // Vegaが小さすぎる場合は収束不可
+      return null
+    }
+
+    sigma = sigma - diff / vega
+
+    if (sigma <= 0) {
+      sigma = 0.001
+    }
+    if (sigma > 5) {
+      return null // 非現実的なIV
+    }
+  }
+
+  return null // 収束しなかった
+}

--- a/src/lib/greeks.ts
+++ b/src/lib/greeks.ts
@@ -1,0 +1,85 @@
+/**
+ * Greeks計算（Black-Scholes Merton 配当調整版）
+ */
+
+import { normalCDF, normalPDF, calculateD1D2, calculateBSPrice, type BSInputs } from './black-scholes'
+
+export interface Greeks {
+  delta: number  // Δ
+  gamma: number  // Γ
+  theta: number  // Θ（1日あたり）
+  vega: number   // ν（1%変化あたり）
+}
+
+/**
+ * Merton配当調整版 Greeks計算
+ *
+ * Delta: Call = e^(-qT) * N(d1), Put = e^(-qT) * (N(d1) - 1)
+ * Gamma: e^(-qT) * φ(d1) / (S * σ * √T)
+ * Theta: 数値微分（1日分の時間変化）
+ * Vega:  S * e^(-qT) * φ(d1) * √T / 100
+ */
+export function calculateGreeks(inputs: BSInputs): Greeks {
+  const { spot, strike, timeToExpiry, volatility, riskFreeRate, dividendYield, optionType } = inputs
+
+  // 満期が極端に近い場合はゼロを返す
+  if (timeToExpiry <= 0 || volatility <= 0) {
+    return { delta: 0, gamma: 0, theta: 0, vega: 0 }
+  }
+
+  const { d1 } = calculateD1D2(inputs)
+  const sqrtT = Math.sqrt(timeToExpiry)
+  const discountDividend = Math.exp(-dividendYield * timeToExpiry)
+
+  // Delta
+  let delta: number
+  if (optionType === 'call') {
+    delta = discountDividend * normalCDF(d1)
+  } else {
+    delta = discountDividend * (normalCDF(d1) - 1)
+  }
+
+  // Gamma（call/put共通）
+  const gamma = (discountDividend * normalPDF(d1)) / (spot * volatility * sqrtT)
+
+  // Theta（数値微分: 1日 = 1/365年）
+  const dt = 1 / 365
+  const priceNow = calculateBSPrice(inputs)
+
+  let thetaPerDay: number
+  if (timeToExpiry > dt) {
+    const priceTomorrow = calculateBSPrice({
+      ...inputs,
+      timeToExpiry: timeToExpiry - dt,
+    })
+    thetaPerDay = priceTomorrow - priceNow
+  } else {
+    // 残り1日未満の場合、イントリンシックバリューとの差
+    const intrinsic = optionType === 'call'
+      ? Math.max(spot - strike, 0)
+      : Math.max(strike - spot, 0)
+    thetaPerDay = intrinsic - priceNow
+  }
+
+  // Vega（IVが1%変化した場合の価格変化）
+  const vega = (spot * discountDividend * normalPDF(d1) * sqrtT) / 100
+
+  return {
+    delta: roundTo(delta, 4),
+    gamma: roundTo(gamma, 6),
+    theta: roundTo(thetaPerDay, 2),
+    vega: roundTo(vega, 2),
+  }
+}
+
+/**
+ * calculateAllGreeks のエイリアス（互換性のため）
+ */
+export function calculateAllGreeks(inputs: BSInputs): Greeks {
+  return calculateGreeks(inputs)
+}
+
+function roundTo(value: number, decimals: number): number {
+  const factor = Math.pow(10, decimals)
+  return Math.round(value * factor) / factor
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -19,6 +19,10 @@ export interface Trade {
   memo: string | null
   status: TradeStatus
   defeat_tags: string[] | null
+  entry_delta: number | null
+  entry_gamma: number | null
+  entry_theta: number | null
+  entry_vega: number | null
 }
 
 export type Database = {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -16,7 +16,11 @@ create table if not exists trades (
   iv_at_entry numeric(6, 2),
   memo text,
   status text not null default 'open' check (status in ('open', 'closed')),
-  defeat_tags text[]
+  defeat_tags text[],
+  entry_delta numeric(8, 4),
+  entry_gamma numeric(10, 6),
+  entry_theta numeric(10, 2),
+  entry_vega numeric(10, 2)
 );
 
 -- updated_at を自動更新するトリガー


### PR DESCRIPTION
## Related Issue
Closes #17

## Summary
- `src/lib/black-scholes.ts`: BS Merton版価格計算、Newton-Raphson法IV逆算
- `src/lib/greeks.ts`: Δ・Γ・Θ・ν計算（Merton配当調整版）
- `src/types/database.ts`: Trade型にGreeksフィールド追加
- `src/app/trades/new/page.tsx`: 先物価格入力・Greeks自動計算・表示UI
- `src/app/actions/trades.ts`: Greeks保存対応
- `supabase/schema.sql`: entry_delta/gamma/theta/vegaカラム追加

## Test plan
- 先物価格・権利行使価格・IV・限月入力時にGreeksが自動計算されること
- 正規分布CDF実装の精度確認
- DBへのGreeks保存が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)