### PR TITLE
feat: iv_historyテーブルとデータ収集API

### DIFF
--- a/src/app/api/iv-data/collect/route.ts
+++ b/src/app/api/iv-data/collect/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import type { IvHistory } from '@/types/database'
+
+type IvDataInput = Omit<IvHistory, 'id'>
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    if (!Array.isArray(body) || body.length === 0) {
+      return NextResponse.json(
+        { error: 'リクエストボディはIVデータの配列である必要があります' },
+        { status: 400 }
+      )
+    }
+
+    // Validate required fields
+    const requiredFields = [
+      'recorded_at',
+      'underlying_price',
+      'strike_price',
+      'expiry_date',
+      'option_type',
+      'iv',
+      'data_source',
+    ] as const
+
+    for (const [index, item] of body.entries()) {
+      for (const field of requiredFields) {
+        if (item[field] === undefined || item[field] === null) {
+          return NextResponse.json(
+            { error: `データ[${index}]に必須フィールド "${field}" がありません` },
+            { status: 400 }
+          )
+        }
+      }
+
+      if (!['call', 'put'].includes(item.option_type)) {
+        return NextResponse.json(
+          { error: `データ[${index}]のoption_typeは "call" または "put" である必要があります` },
+          { status: 400 }
+        )
+      }
+    }
+
+    // Check for duplicates based on recorded_at + strike_price + expiry_date + option_type
+    const duplicateChecks = body.map((item: IvDataInput) => ({
+      recorded_at: item.recorded_at,
+      strike_price: item.strike_price,
+      expiry_date: item.expiry_date,
+      option_type: item.option_type,
+    }))
+
+    const { data: existingRecords, error: checkError } = await supabase
+      .from('iv_history')
+      .select('recorded_at, strike_price, expiry_date, option_type')
+
+    if (checkError) {
+      console.error('重複チェックエラー:', checkError)
+      return NextResponse.json(
+        { error: '重複チェック中にエラーが発生しました' },
+        { status: 500 }
+      )
+    }
+
+    // Build a set of existing keys for fast lookup
+    const existingKeys = new Set(
+      (existingRecords ?? []).map(
+        (r: { recorded_at: string; strike_price: number; expiry_date: string; option_type: string }) =>
+          `${r.recorded_at}|${r.strike_price}|${r.expiry_date}|${r.option_type}`
+      )
+    )
+
+    // Filter out duplicates
+    const newRecords = body.filter((item: IvDataInput) => {
+      const key = `${item.recorded_at}|${item.strike_price}|${item.expiry_date}|${item.option_type}`
+      return !existingKeys.has(key)
+    })
+
+    if (newRecords.length === 0) {
+      return NextResponse.json({
+        message: '全てのデータが既に存在しています',
+        inserted: 0,
+        duplicates: body.length,
+      })
+    }
+
+    // Insert new records
+    const { data, error: insertError } = await supabase
+      .from('iv_history')
+      .insert(newRecords)
+      .select()
+
+    if (insertError) {
+      console.error('データ挿入エラー:', insertError)
+      return NextResponse.json(
+        { error: 'データの保存中にエラーが発生しました' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      message: 'IVデータを保存しました',
+      inserted: (data ?? []).length,
+      duplicates: body.length - (data ?? []).length,
+    })
+  } catch (error) {
+    console.error('予期しないエラー:', error)
+    return NextResponse.json(
+      { error: 'サーバーエラーが発生しました' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -35,6 +35,23 @@ export interface JQuantsToken {
   updated_at: string
 }
 
+export interface IvHistory {
+  id: string
+  recorded_at: string
+  underlying_price: number
+  strike_price: number
+  expiry_date: string
+  option_type: 'call' | 'put'
+  iv: number
+  iv_rank: number | null
+  iv_percentile: number | null
+  hv20: number | null
+  hv60: number | null
+  nikkei_vi: number | null
+  pcr: number | null
+  data_source: string
+}
+
 export type Database = {
   public: {
     Tables: {
@@ -48,6 +65,12 @@ export type Database = {
         Row: JQuantsToken
         Insert: Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>
         Update: Partial<Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>>
+        Relationships: []
+      }
+      iv_history: {
+        Row: IvHistory
+        Insert: Omit<IvHistory, 'id'>
+        Update: Partial<Omit<IvHistory, 'id'>>
         Relationships: []
       }
     }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -63,3 +63,26 @@ create table if not exists j_quants_tokens (
 create trigger j_quants_tokens_updated_at
   before update on j_quants_tokens
   for each row execute function update_updated_at();
+
+-- =============================================
+-- IV履歴テーブル
+-- =============================================
+CREATE TABLE iv_history (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  underlying_price numeric(10, 2) NOT NULL,
+  strike_price integer NOT NULL,
+  expiry_date date NOT NULL,
+  option_type text NOT NULL CHECK (option_type IN ('call', 'put')),
+  iv numeric(8, 4) NOT NULL,
+  iv_rank numeric(5, 2),
+  iv_percentile numeric(5, 2),
+  hv20 numeric(8, 4),
+  hv60 numeric(8, 4),
+  nikkei_vi numeric(6, 2),
+  pcr numeric(6, 3),
+  data_source text NOT NULL
+);
+
+CREATE INDEX iv_history_recorded_at_idx ON iv_history (recorded_at DESC);
+CREATE INDEX iv_history_option_lookup_idx ON iv_history (strike_price, expiry_date, option_type, recorded_at DESC);


### PR DESCRIPTION
## Related Issue
Closes #8

## Summary
- `iv_history`テーブルのスキーマ定義（schema.sql）とTypeScript型定義を追加
- `POST /api/iv-data/collect` APIエンドポイントを実装
- 重複チェック・バリデーション・エラーハンドリング付き

## Test plan
- [ ] `supabase/schema.sql`のiv_historyテーブルをSupabaseで実行
- [ ] APIにPOSTリクエストを送信してデータが保存されることを確認
- [ ] 重複データが挿入されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)