### PR TITLE
feat: Web Push通知連携

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,3 +5,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # J-Quants API
 J_QUANTS_MAIL_ADDRESS=your_email
 J_QUANTS_PASSWORD=your_password
+
+# Web Push (VAPID)
+# Generate keys with: npx web-push generate-vapid-keys
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your-vapid-public-key
+VAPID_PRIVATE_KEY=your-vapid-private-key
+VAPID_SUBJECT=mailto:your-email@example.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,15 @@
         "@supabase/supabase-js": "^2.98.0",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "@vitejs/plugin-react": "^5.1.4",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
@@ -2402,6 +2404,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3084,6 +3095,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3282,6 +3301,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3356,6 +3386,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3410,6 +3445,11 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3627,7 +3667,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3713,6 +3752,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4829,6 +4876,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -4870,6 +4937,11 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5386,6 +5458,25 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5757,6 +5848,11 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5773,7 +5869,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5781,8 +5876,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6469,6 +6563,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6501,6 +6614,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -7479,6 +7597,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
     "@supabase/supabase-js": "^2.98.0",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "@vitejs/plugin-react": "^5.1.4",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,73 @@
+// Service Worker for Web Push Notifications
+
+self.addEventListener('install', (event) => {
+  console.log('[SW] Service Worker installed')
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  console.log('[SW] Service Worker activated')
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('push', (event) => {
+  console.log('[SW] Push notification received')
+
+  let data = {
+    title: 'NK225 Options',
+    body: '新しい通知があります',
+    icon: '/next.svg',
+    badge: '/next.svg',
+    url: '/',
+  }
+
+  if (event.data) {
+    try {
+      const payload = event.data.json()
+      data = { ...data, ...payload }
+    } catch {
+      data.body = event.data.text()
+    }
+  }
+
+  const options = {
+    body: data.body,
+    icon: data.icon,
+    badge: data.badge,
+    vibrate: [100, 50, 100],
+    data: {
+      url: data.url,
+    },
+    actions: [
+      { action: 'open', title: '開く' },
+      { action: 'close', title: '閉じる' },
+    ],
+  }
+
+  event.waitUntil(self.registration.showNotification(data.title, options))
+})
+
+self.addEventListener('notificationclick', (event) => {
+  console.log('[SW] Notification clicked')
+  event.notification.close()
+
+  const url = event.notification.data?.url || '/'
+
+  if (event.action === 'close') {
+    return
+  }
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if (client.url.includes(self.location.origin) && 'focus' in client) {
+            client.navigate(url)
+            return client.focus()
+          }
+        }
+        return self.clients.openWindow(url)
+      })
+  )
+})

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server'
+import webpush from 'web-push'
+import { supabase } from '@/lib/supabase'
+import type { PushSubscriptionRow } from '@/types/database'
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || ''
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || ''
+const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:admin@example.com'
+
+// VAPID設定
+if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(VAPID_SUBJECT, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY)
+}
+
+interface SendPushBody {
+  title?: string
+  body: string
+  url?: string
+  icon?: string
+}
+
+/**
+ * POST /api/push/send
+ * 全登録ブラウザにPush通知を送信
+ */
+export async function POST(request: NextRequest) {
+  try {
+    if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+      return NextResponse.json(
+        { error: 'VAPID keys are not configured' },
+        { status: 500 }
+      )
+    }
+
+    const body: SendPushBody = await request.json()
+
+    if (!body.body) {
+      return NextResponse.json(
+        { error: 'Notification body is required' },
+        { status: 400 }
+      )
+    }
+
+    // 全サブスクリプションを取得
+    const { data: subscriptions, error } = await supabase
+      .from('push_subscriptions')
+      .select('*')
+
+    if (error) {
+      console.error('[Push Send] Failed to fetch subscriptions:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch subscriptions' },
+        { status: 500 }
+      )
+    }
+
+    if (!subscriptions || subscriptions.length === 0) {
+      return NextResponse.json(
+        { message: 'No subscriptions found', sent: 0 }
+      )
+    }
+
+    const payload = JSON.stringify({
+      title: body.title || 'NK225 Options',
+      body: body.body,
+      url: body.url || '/',
+      icon: body.icon || '/next.svg',
+    })
+
+    // 各サブスクリプションに送信
+    const results = await Promise.allSettled(
+      (subscriptions as PushSubscriptionRow[]).map(async (sub) => {
+        const pushSubscription = {
+          endpoint: sub.endpoint,
+          keys: {
+            p256dh: sub.p256dh,
+            auth: sub.auth,
+          },
+        }
+
+        try {
+          await webpush.sendNotification(pushSubscription, payload)
+          return { endpoint: sub.endpoint, success: true }
+        } catch (err: unknown) {
+          const webPushError = err as { statusCode?: number }
+          // 410 Gone or 404 Not Found = subscription expired
+          if (webPushError.statusCode === 410 || webPushError.statusCode === 404) {
+            console.log('[Push Send] Removing expired subscription:', sub.endpoint)
+            await supabase
+              .from('push_subscriptions')
+              .delete()
+              .eq('endpoint', sub.endpoint)
+          }
+          throw err
+        }
+      })
+    )
+
+    const sent = results.filter((r) => r.status === 'fulfilled').length
+    const failed = results.filter((r) => r.status === 'rejected').length
+
+    return NextResponse.json({
+      message: `Push notifications sent`,
+      sent,
+      failed,
+      total: subscriptions.length,
+    })
+  } catch (error) {
+    console.error('[Push Send] Error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+/**
+ * POST /api/push/subscribe
+ * PushSubscriptionをSupabaseに保存
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { subscription } = body
+
+    if (!subscription || !subscription.endpoint) {
+      return NextResponse.json(
+        { error: 'Invalid subscription: endpoint is required' },
+        { status: 400 }
+      )
+    }
+
+    // endpoint をキーに upsert（同じブラウザの再登録に対応）
+    const { error } = await supabase
+      .from('push_subscriptions')
+      .upsert(
+        {
+          endpoint: subscription.endpoint,
+          p256dh: subscription.keys?.p256dh || null,
+          auth: subscription.keys?.auth || null,
+          user_agent: request.headers.get('user-agent') || null,
+        },
+        { onConflict: 'endpoint' }
+      )
+
+    if (error) {
+      console.error('[Push API] Failed to save subscription:', error)
+      return NextResponse.json(
+        { error: 'Failed to save subscription' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ message: 'Subscription saved' })
+  } catch (error) {
+    console.error('[Push API] Error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/push/subscribe
+ * PushSubscriptionをSupabaseから削除
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { endpoint } = body
+
+    if (!endpoint) {
+      return NextResponse.json(
+        { error: 'Endpoint is required' },
+        { status: 400 }
+      )
+    }
+
+    const { error } = await supabase
+      .from('push_subscriptions')
+      .delete()
+      .eq('endpoint', endpoint)
+
+    if (error) {
+      console.error('[Push API] Failed to delete subscription:', error)
+      return NextResponse.json(
+        { error: 'Failed to delete subscription' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ message: 'Subscription deleted' })
+  } catch (error) {
+    console.error('[Push API] Error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import Nav from '@/components/Nav'
+import ServiceWorkerRegistration from '@/components/ServiceWorkerRegistration'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -29,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-950 text-slate-100 min-h-screen`}
       >
         <Nav />
+        <ServiceWorkerRegistration />
         <div className="pt-14">{children}</div>
       </body>
     </html>

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js', { scope: '/' })
+        .then((registration) => {
+          console.log('[SW] Registered:', registration.scope)
+        })
+        .catch((error) => {
+          console.error('[SW] Registration failed:', error)
+        })
+    }
+  }, [])
+
+  return null
+}

--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -1,0 +1,192 @@
+/**
+ * Web Push通知 - VAPID-based subscription management
+ */
+
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || ''
+
+/**
+ * VAPID公開鍵をUint8Arrayに変換
+ */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = window.atob(base64)
+  const outputArray = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i)
+  }
+  return outputArray
+}
+
+/**
+ * Service Workerが対応しているかチェック
+ */
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window &&
+    'Notification' in window
+  )
+}
+
+/**
+ * 現在の通知権限を取得
+ */
+export function getPermissionState(): NotificationPermission | 'unsupported' {
+  if (!isPushSupported()) return 'unsupported'
+  return Notification.permission
+}
+
+/**
+ * Service Workerを登録
+ */
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!isPushSupported()) {
+    console.warn('[Push] Push notifications are not supported in this browser')
+    return null
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register('/sw.js', {
+      scope: '/',
+    })
+    console.log('[Push] Service Worker registered:', registration.scope)
+    return registration
+  } catch (error) {
+    console.error('[Push] Service Worker registration failed:', error)
+    return null
+  }
+}
+
+/**
+ * 通知権限をリクエスト
+ */
+export async function requestPermission(): Promise<NotificationPermission> {
+  if (!isPushSupported()) {
+    throw new Error('Push notifications are not supported')
+  }
+
+  const permission = await Notification.requestPermission()
+  console.log('[Push] Permission:', permission)
+  return permission
+}
+
+/**
+ * Push通知をサブスクライブし、サーバーに登録
+ */
+export async function subscribe(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) {
+    throw new Error('Push notifications are not supported')
+  }
+
+  if (!VAPID_PUBLIC_KEY) {
+    throw new Error('VAPID public key is not configured')
+  }
+
+  const permission = await requestPermission()
+  if (permission !== 'granted') {
+    console.warn('[Push] Permission denied')
+    return null
+  }
+
+  const registration = await registerServiceWorker()
+  if (!registration) {
+    throw new Error('Service Worker registration failed')
+  }
+
+  try {
+    // 既存のサブスクリプションがあれば返す
+    const existingSubscription = await registration.pushManager.getSubscription()
+    if (existingSubscription) {
+      console.log('[Push] Using existing subscription')
+      await saveSubscription(existingSubscription)
+      return existingSubscription
+    }
+
+    // 新しいサブスクリプションを作成
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY) as BufferSource,
+    })
+
+    console.log('[Push] New subscription created')
+    await saveSubscription(subscription)
+    return subscription
+  } catch (error) {
+    console.error('[Push] Subscribe failed:', error)
+    throw error
+  }
+}
+
+/**
+ * Push通知のサブスクリプションを解除
+ */
+export async function unsubscribe(): Promise<boolean> {
+  if (!isPushSupported()) return false
+
+  const registration = await navigator.serviceWorker.ready
+  const subscription = await registration.pushManager.getSubscription()
+
+  if (!subscription) {
+    console.log('[Push] No subscription to unsubscribe')
+    return true
+  }
+
+  try {
+    // サーバーから削除
+    await deleteSubscription(subscription)
+    // ブラウザから削除
+    const result = await subscription.unsubscribe()
+    console.log('[Push] Unsubscribed:', result)
+    return result
+  } catch (error) {
+    console.error('[Push] Unsubscribe failed:', error)
+    return false
+  }
+}
+
+/**
+ * 現在のサブスクリプション状態を取得
+ */
+export async function getSubscription(): Promise<PushSubscription | null> {
+  if (!isPushSupported()) return null
+
+  try {
+    const registration = await navigator.serviceWorker.ready
+    return await registration.pushManager.getSubscription()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * サブスクリプションをサーバーに保存
+ */
+async function saveSubscription(subscription: PushSubscription): Promise<void> {
+  const response = await fetch('/api/push/subscribe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ subscription: subscription.toJSON() }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(error.error || 'Failed to save subscription')
+  }
+}
+
+/**
+ * サブスクリプションをサーバーから削除
+ */
+async function deleteSubscription(subscription: PushSubscription): Promise<void> {
+  const response = await fetch('/api/push/subscribe', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ endpoint: subscription.endpoint }),
+  })
+
+  if (!response.ok) {
+    console.error('[Push] Failed to delete subscription from server')
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -35,6 +35,16 @@ export interface JQuantsToken {
   updated_at: string
 }
 
+export interface PushSubscriptionRow {
+  id: string
+  endpoint: string
+  p256dh: string
+  auth: string
+  user_agent: string | null
+  created_at: string
+  updated_at: string
+}
+
 export type Database = {
   public: {
     Tables: {
@@ -48,6 +58,12 @@ export type Database = {
         Row: JQuantsToken
         Insert: Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>
         Update: Partial<Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>>
+        Relationships: []
+      }
+      push_subscriptions: {
+        Row: PushSubscriptionRow
+        Insert: Omit<PushSubscriptionRow, 'id' | 'created_at' | 'updated_at'>
+        Update: Partial<Omit<PushSubscriptionRow, 'id' | 'created_at' | 'updated_at'>>
         Relationships: []
       }
     }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -63,3 +63,24 @@ create table if not exists j_quants_tokens (
 create trigger j_quants_tokens_updated_at
   before update on j_quants_tokens
   for each row execute function update_updated_at();
+
+-- =============================================
+-- Web Push通知 サブスクリプション管理テーブル
+-- =============================================
+create table if not exists push_subscriptions (
+  id uuid primary key default gen_random_uuid(),
+  endpoint text not null unique,
+  p256dh text not null,
+  auth text not null,
+  user_agent text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- updated_at を自動更新するトリガー
+create trigger push_subscriptions_updated_at
+  before update on push_subscriptions
+  for each row execute function update_updated_at();
+
+-- インデックス
+create index if not exists push_subscriptions_endpoint_idx on push_subscriptions (endpoint);


### PR DESCRIPTION
## Related Issue
Closes #15

## Summary
- Service Worker (`public/sw.js`) でPush受信・通知表示
- VAPID鍵ベースの購読管理ライブラリ (`push-notifications.ts`)
- 購読保存API (`/api/push/subscribe`) と通知送信API (`/api/push/send`)
- `push_subscriptions` テーブル追加
- `web-push` パッケージ追加

## Test plan
- [ ] Service Workerが正常に登録されることを確認
- [ ] Push通知の購読・購読解除が動作すること
- [ ] `/api/push/send` で通知が受信されること
- [ ] 期限切れ購読の自動クリーンアップ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)