### PR TITLE
feat: IVシグナル判定ロジック（2段階閾値）

### DIFF
--- a/src/lib/__tests__/iv-signals.test.ts
+++ b/src/lib/__tests__/iv-signals.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { detectSignal, calculateIVAverage, type IVSignalType } from '../iv-signals'
+
+describe('calculateIVAverage', () => {
+  it('IV配列の平均を正しく算出する', () => {
+    expect(calculateIVAverage([20, 22, 24, 26, 28])).toBe(24)
+  })
+
+  it('単一要素の場合はその値を返す', () => {
+    expect(calculateIVAverage([15])).toBe(15)
+  })
+
+  it('空配列の場合はnullを返す', () => {
+    expect(calculateIVAverage([])).toBeNull()
+  })
+
+  it('小数点のIV値でも正しく計算する', () => {
+    const result = calculateIVAverage([20.5, 21.5])
+    expect(result).toBe(21)
+  })
+})
+
+describe('detectSignal', () => {
+  describe('通常買いシグナル', () => {
+    it('現在IVが20日平均より15%以上低い場合に「通常買い」を返す', () => {
+      // iv20Avg = 100, 15%低い = 85, iv60Avg = 100 → 85 <= 80? NO → 強買いにはならない
+      const result = detectSignal(85, 100, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('normal_buy' satisfies IVSignalType)
+      expect(result!.message).toBe('IV低下：買い検討タイミング')
+    })
+
+    it('ちょうど15%低い場合もシグナルを返す（境界値）', () => {
+      // iv20Avg = 100, ちょうど15%低い = 85
+      const result = detectSignal(85, 100, 80)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('normal_buy' satisfies IVSignalType)
+    })
+
+    it('14.9%低い場合はシグナルを返さない（境界値）', () => {
+      // iv20Avg = 100, 14.9%低い = 85.1
+      const result = detectSignal(85.1, 100, 80)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('強買いシグナル', () => {
+    it('現在IVが60日平均より20%以上低く、かつ20日平均も下回る場合に「強買い」を返す', () => {
+      // iv60Avg = 100, 20%低い = 80, iv20Avg = 90, currentIV = 75 (< 80 かつ < 90)
+      const result = detectSignal(75, 90, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('strong_buy' satisfies IVSignalType)
+      expect(result!.message).toBe('強IVシグナル：買い好機')
+    })
+
+    it('60日平均よりちょうど20%低く20日平均も下回る場合もシグナルを返す（境界値）', () => {
+      // iv60Avg = 100, ちょうど20%低い = 80, iv20Avg = 90, currentIV = 80 (= 80 かつ < 90)
+      const result = detectSignal(80, 90, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('strong_buy' satisfies IVSignalType)
+    })
+
+    it('60日平均より20%以上低いが20日平均を上回る場合は強買いにならない', () => {
+      // iv60Avg = 100, currentIV = 79 (< 80) だが iv20Avg = 75 → currentIV > iv20Avg
+      const result = detectSignal(79, 75, 100)
+      // 20日平均より上 → 通常買いではない、強買い条件の20日平均下回りも不成立
+      // ただし60日比は20%超低い... 20日平均を下回る必要あり
+      expect(result).toBeNull()
+    })
+
+    it('強買い条件と通常買い条件の両方を満たす場合は強買いが優先される', () => {
+      // iv20Avg = 100, iv60Avg = 100
+      // currentIV = 75 → 20日平均比25%低い(>15%) かつ 60日平均比25%低い(>20%) かつ 20日平均下回る
+      const result = detectSignal(75, 100, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('strong_buy' satisfies IVSignalType)
+    })
+  })
+
+  describe('売りシグナル', () => {
+    it('現在IVが20日平均より20%以上高い場合に「売り」を返す', () => {
+      // iv20Avg = 100, 20%高い = 120 → currentIV >= 120 でシグナル
+      const result = detectSignal(120, 100, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('sell' satisfies IVSignalType)
+      expect(result!.message).toBe('IV上昇：売り/ヘッジ検討')
+    })
+
+    it('ちょうど20%高い場合もシグナルを返す（境界値）', () => {
+      const result = detectSignal(120, 100, 100)
+      expect(result).not.toBeNull()
+      expect(result!.type).toBe('sell' satisfies IVSignalType)
+    })
+
+    it('19.9%高い場合はシグナルを返さない（境界値）', () => {
+      // iv20Avg = 100, 19.9%高い = 119.9
+      const result = detectSignal(119.9, 100, 100)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('シグナルなし', () => {
+    it('どの条件も満たさない場合はnullを返す', () => {
+      // iv20Avg = 100, currentIV = 95 → 5%低い（15%未満）
+      const result = detectSignal(95, 100, 100)
+      expect(result).toBeNull()
+    })
+
+    it('IV値が平均とほぼ同じ場合はnullを返す', () => {
+      const result = detectSignal(100, 100, 100)
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/src/lib/iv-signals.ts
+++ b/src/lib/iv-signals.ts
@@ -1,0 +1,78 @@
+/**
+ * IVシグナル判定ロジック（2段階閾値）
+ *
+ * IVの移動平均との乖離に基づき3種類のシグナルを判定する。
+ * | シグナル | 条件 |
+ * |---------|------|
+ * | 通常買い | 現在IVが20日平均より15%以上低い |
+ * | 強買い   | 現在IVが60日平均より20%以上低い、かつ20日平均も下回る |
+ * | 売り     | 現在IVが20日平均より20%以上高い |
+ */
+
+export type IVSignalType = 'normal_buy' | 'strong_buy' | 'sell'
+
+export interface IVSignal {
+  type: IVSignalType
+  message: string
+}
+
+const SIGNAL_MESSAGES: Record<IVSignalType, string> = {
+  normal_buy: 'IV低下：買い検討タイミング',
+  strong_buy: '強IVシグナル：買い好機',
+  sell: 'IV上昇：売り/ヘッジ検討',
+}
+
+/**
+ * IV配列の平均値を算出する
+ *
+ * @param ivValues IV値の配列
+ * @returns 平均値。空配列の場合はnull
+ */
+export function calculateIVAverage(ivValues: number[]): number | null {
+  if (ivValues.length === 0) {
+    return null
+  }
+  const sum = ivValues.reduce((acc, val) => acc + val, 0)
+  return sum / ivValues.length
+}
+
+/**
+ * シグナル判定を行う
+ *
+ * 優先順位: 強買い > 売り > 通常買い
+ * - 強買い: currentIV <= iv60Avg * 0.8 かつ currentIV < iv20Avg
+ * - 売り:   currentIV >= iv20Avg * 1.2
+ * - 通常買い: currentIV <= iv20Avg * 0.85
+ *
+ * @param currentIV 現在のIV
+ * @param iv20Avg 20日移動平均IV
+ * @param iv60Avg 60日移動平均IV
+ * @returns IVSignal または null（シグナルなし）
+ */
+export function detectSignal(
+  currentIV: number,
+  iv20Avg: number,
+  iv60Avg: number
+): IVSignal | null {
+  const isStrongBuy =
+    currentIV <= iv60Avg * (1 - 0.2) && currentIV < iv20Avg
+  const isSell = currentIV >= iv20Avg * (1 + 0.2)
+  const isNormalBuy = currentIV <= iv20Avg * (1 - 0.15)
+
+  // 強買いが最優先
+  if (isStrongBuy) {
+    return { type: 'strong_buy', message: SIGNAL_MESSAGES.strong_buy }
+  }
+
+  // 売りシグナル
+  if (isSell) {
+    return { type: 'sell', message: SIGNAL_MESSAGES.sell }
+  }
+
+  // 通常買いシグナル
+  if (isNormalBuy) {
+    return { type: 'normal_buy', message: SIGNAL_MESSAGES.normal_buy }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- IVの移動平均との乖離に基づく3種類のシグナル判定ロジックを `src/lib/iv-signals.ts` に実装
- `calculateIVAverage()`: IV配列の平均値算出
- `detectSignal()`: 通常買い / 強買い / 売りの3シグナル判定（優先順位: 強買い > 売り > 通常買い）
- 境界値テストを含む16テストケースを追加（全てパス）

## Test plan
- [x] 通常買いシグナル: 現在IVが20日平均より15%以上低い場合に判定
- [x] 強買いシグナル: 現在IVが60日平均より20%以上低い＋20日平均も下回る場合に判定
- [x] 売りシグナル: 現在IVが20日平均より20%以上高い場合に判定
- [x] 境界値テスト（15%/20%の閾値付近）
- [x] シグナルなしの場合にnullが返る
- [x] 全22テスト通過（既存6 + 新規16）

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)