### PR TITLE
feat: IVデータ定期取得バッチAPIルート(#12)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,3 +5,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # J-Quants API
 J_QUANTS_MAIL_ADDRESS=your_email
 J_QUANTS_PASSWORD=your_password
+
+# Cron batch job authentication
+CRON_SECRET=your_cron_secret

--- a/src/app/api/iv-data/__tests__/batch-collect.test.ts
+++ b/src/app/api/iv-data/__tests__/batch-collect.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock dependencies before importing the route
+vi.mock('@/lib/jquants-token', () => ({
+  getValidIdToken: vi.fn(),
+}))
+
+vi.mock('@/lib/jquants', () => ({
+  fetchOptionPrices: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}))
+
+import { GET } from '../../iv-data/batch-collect/route'
+import { getValidIdToken } from '@/lib/jquants-token'
+import { fetchOptionPrices } from '@/lib/jquants'
+import { supabase } from '@/lib/supabase'
+
+const mockedGetValidIdToken = vi.mocked(getValidIdToken)
+const mockedFetchOptionPrices = vi.mocked(fetchOptionPrices)
+const mockedSupabase = vi.mocked(supabase)
+
+function createRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost:3000/api/iv-data/batch-collect', {
+    method: 'GET',
+    headers,
+  })
+}
+
+describe('GET /api/iv-data/batch-collect', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // Set CRON_SECRET env var
+    process.env.CRON_SECRET = 'test-secret-123'
+  })
+
+  it('CRON_SECRETなしのリクエストは401を返す', async () => {
+    const request = createRequest()
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+    const body = await response.json()
+    expect(body.error).toBeDefined()
+  })
+
+  it('不正なCRON_SECRETのリクエストは401を返す', async () => {
+    const request = createRequest({
+      Authorization: 'Bearer wrong-secret',
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('正しいCRON_SECRETで認証が通る', async () => {
+    // Setup mocks for successful flow
+    mockedGetValidIdToken.mockResolvedValue('mock-id-token')
+    mockedFetchOptionPrices.mockResolvedValue([
+      {
+        Date: '2026-03-11',
+        Code: '130060018',
+        WholeDayOpen: 500,
+        WholeDayHigh: 520,
+        WholeDayLow: 490,
+        WholeDayClose: 510,
+        Volume: 100,
+        OpenInterest: 200,
+        TurnoverValue: 5000000,
+        ContractMonth: '2026-04',
+        StrikePrice: 38000,
+        PutCallDivision: '2', // Call
+        ImpliedVolatility: 20.5,
+        UnderlyingPrice: 38000,
+        TheoreticalPrice: 510,
+      },
+    ])
+
+    // Mock supabase select for historical data
+    const selectMock = vi.fn().mockReturnValue({
+      order: vi.fn().mockResolvedValue({
+        data: [
+          { iv_value: 18.0, recorded_at: '2025-03-11' },
+          { iv_value: 22.0, recorded_at: '2025-06-11' },
+          { iv_value: 25.0, recorded_at: '2025-09-11' },
+        ],
+        error: null,
+      }),
+    })
+
+    const insertMock = vi.fn().mockResolvedValue({
+      data: null,
+      error: null,
+    })
+
+    mockedSupabase.from = vi.fn().mockImplementation((table: string) => {
+      if (table === 'iv_history') {
+        return {
+          select: selectMock,
+          insert: insertMock,
+        }
+      }
+      return { select: vi.fn(), insert: vi.fn() }
+    }) as ReturnType<typeof vi.fn>
+
+    const request = createRequest({
+      Authorization: 'Bearer test-secret-123',
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toBeDefined()
+    expect(body.data.atmIv).toBeDefined()
+    expect(body.data.ivRank).toBeDefined()
+  })
+
+  it('J-Quants APIエラー時に500を返す', async () => {
+    mockedGetValidIdToken.mockRejectedValue(
+      new Error('J-Quants API error'),
+    )
+
+    const request = createRequest({
+      Authorization: 'Bearer test-secret-123',
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body.error).toBeDefined()
+  })
+
+  it('CRON_SECRET環境変数が未設定の場合は401を返す', async () => {
+    delete process.env.CRON_SECRET
+
+    const request = createRequest({
+      Authorization: 'Bearer test-secret-123',
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(401)
+  })
+
+  it('IVデータがない場合は適切にハンドリングする', async () => {
+    mockedGetValidIdToken.mockResolvedValue('mock-id-token')
+    mockedFetchOptionPrices.mockResolvedValue([])
+
+    // Mock supabase for historical data query (no insert since atmIv is null)
+    mockedSupabase.from = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [],
+          error: null,
+        }),
+      }),
+      insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }) as ReturnType<typeof vi.fn>
+
+    const request = createRequest({
+      Authorization: 'Bearer test-secret-123',
+    })
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.data.atmIv).toBeNull()
+  })
+})

--- a/src/app/api/iv-data/batch-collect/route.ts
+++ b/src/app/api/iv-data/batch-collect/route.ts
@@ -1,0 +1,162 @@
+/**
+ * バッチ処理APIルート - IVデータの定期取得
+ *
+ * 外部cronサービス（cron-job.org等）から定期的に呼び出される。
+ * 取得タイミング: 日中クローズ（15:15 JST）/ 夜間クローズ（翌6:00 JST）
+ *
+ * 認証: Authorization: Bearer <CRON_SECRET>
+ *
+ * 処理フロー:
+ * 1. CRON_SECRET で認証
+ * 2. J-Quants APIからオプション価格（IV含む）を取得
+ * 3. ATM IVを算出
+ * 4. iv_history テーブルに蓄積
+ * 5. 過去1年のIVデータからIVランクを計算
+ * 6. シグナル判定
+ */
+
+import { NextResponse } from 'next/server'
+import { getValidIdToken } from '@/lib/jquants-token'
+import { fetchOptionPrices, type JQuantsOptionPrice } from '@/lib/jquants'
+import { supabase } from '@/lib/supabase'
+import { calculateIvRank, calculateIvPercentile } from '@/lib/iv-calculations'
+
+/**
+ * ATM（At The Money）のIVを算出する
+ *
+ * 原資産価格に最も近い行使価格のコールとプットのIVを平均する。
+ */
+function calculateAtmIv(options: JQuantsOptionPrice[]): number | null {
+  // IV が存在し、原資産価格が取得できるオプションのみフィルタ
+  const withIv = options.filter(
+    (o) => o.ImpliedVolatility != null && o.UnderlyingPrice != null,
+  )
+
+  if (withIv.length === 0) return null
+
+  const underlyingPrice = withIv[0].UnderlyingPrice!
+
+  // 行使価格が原資産価格に最も近いものを見つける
+  let closestStrike = withIv[0].StrikePrice
+  let minDiff = Math.abs(closestStrike - underlyingPrice)
+
+  for (const opt of withIv) {
+    const diff = Math.abs(opt.StrikePrice - underlyingPrice)
+    if (diff < minDiff) {
+      minDiff = diff
+      closestStrike = opt.StrikePrice
+    }
+  }
+
+  // ATM行使価格のオプションのIVを収集
+  const atmOptions = withIv.filter((o) => o.StrikePrice === closestStrike)
+  if (atmOptions.length === 0) return null
+
+  const avgIv =
+    atmOptions.reduce((sum, o) => sum + o.ImpliedVolatility!, 0) /
+    atmOptions.length
+
+  return Math.round(avgIv * 100) / 100
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  // 1. CRON_SECRET 認証
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: 'CRON_SECRET is not configured' },
+      { status: 401 },
+    )
+  }
+
+  const authHeader = request.headers.get('Authorization')
+  const token = authHeader?.replace('Bearer ', '')
+
+  if (token !== cronSecret) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401 },
+    )
+  }
+
+  try {
+    // 2. J-Quants APIからオプション価格データを取得
+    const idToken = await getValidIdToken()
+    const options = await fetchOptionPrices(idToken)
+
+    // 3. ATM IVを算出
+    const atmIv = calculateAtmIv(options)
+
+    const now = new Date().toISOString()
+
+    // 4. iv_history テーブルに蓄積（ATM IVがある場合のみ）
+    if (atmIv !== null) {
+      const { error: insertError } = await supabase
+        .from('iv_history')
+        .insert({
+          iv_value: atmIv,
+          recorded_at: now,
+        })
+
+      if (insertError) {
+        console.error('Failed to insert IV history:', insertError)
+        return NextResponse.json(
+          { error: `Failed to store IV data: ${insertError.message}` },
+          { status: 500 },
+        )
+      }
+    }
+
+    // 5. 過去1年のIVデータを取得してIVランクを計算
+    const { data: historicalData, error: historyError } = await supabase
+      .from('iv_history')
+      .select('iv_value, recorded_at')
+      .order('recorded_at', { ascending: true })
+
+    if (historyError) {
+      console.error('Failed to fetch IV history:', historyError)
+    }
+
+    const historicalIvs = (historicalData ?? []).map(
+      (row: { iv_value: number }) => row.iv_value,
+    )
+
+    let ivRank: number | null = null
+    let ivPercentile: number | null = null
+    let signal: string | null = null
+
+    if (atmIv !== null && historicalIvs.length > 0) {
+      const minIv = Math.min(...historicalIvs)
+      const maxIv = Math.max(...historicalIvs)
+
+      ivRank = calculateIvRank(atmIv, minIv, maxIv)
+      ivPercentile = calculateIvPercentile(atmIv, historicalIvs)
+
+      // 6. シグナル判定
+      if (ivRank <= 25) {
+        signal = 'BUY' // IV低水準 → 買い好機
+      } else if (ivRank >= 75) {
+        signal = 'SELL' // IV高水準 → 売り好機
+      } else {
+        signal = 'NEUTRAL'
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        atmIv,
+        ivRank,
+        ivPercentile,
+        signal,
+        optionsCount: options.length,
+        recordedAt: now,
+      },
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    console.error('Batch collect error:', message)
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- 外部cronサービス（cron-job.org等）から `CRON_SECRET` で認証して呼び出すバッチ処理APIを実装
- `GET /api/iv-data/batch-collect` でJ-Quants APIからオプション価格を取得し、ATM IV算出 → iv_history蓄積 → IVランク計算 → シグナル判定
- `.env.local.example` に `CRON_SECRET` を追加

## Changed files
| File | Change |
|------|--------|
| `src/app/api/iv-data/batch-collect/route.ts` | **New** - バッチAPI |
| `src/app/api/iv-data/__tests__/batch-collect.test.ts` | **New** - テスト6件 |
| `.env.local.example` | `CRON_SECRET` 追加 |

## Test plan
- [x] 認証なしリクエストが401で拒否されること
- [x] 不正なCRON_SECRETが401で拒否されること
- [x] CRON_SECRET環境変数未設定時に401を返すこと
- [x] 正しい認証でデータ取得・蓄積が正常に完了すること
- [x] J-Quants APIエラー時に500を返すこと
- [x] IVデータがない場合に適切にハンドリングすること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)