### PR TITLE
feat: iv_historyテーブルとIVデータ蓄積APIを追加

### DIFF
--- a/src/app/api/iv-data/collect/route.ts
+++ b/src/app/api/iv-data/collect/route.ts
@@ -1,0 +1,43 @@
+/**
+ * IV データ蓄積 API エンドポイント
+ *
+ * POST /api/iv-data/collect
+ * J-Quants APIからATM周辺のオプションIVデータを取得し、
+ * iv_historyテーブルに蓄積する。
+ *
+ * リクエストボディ（任意）:
+ * - date: string (YYYY-MM-DD形式。省略時は直近営業日)
+ *
+ * 認証: API_SECRET_KEY ヘッダーで簡易認証（cronジョブからの呼び出し想定）
+ */
+
+import { NextResponse } from 'next/server'
+import { collectIvData } from '@/lib/iv-collect'
+
+export async function POST(request: Request) {
+  // 簡易認証: API_SECRET_KEY が設定されている場合はチェック
+  const apiSecretKey = process.env.API_SECRET_KEY
+  if (apiSecretKey) {
+    const authHeader = request.headers.get('x-api-key')
+    if (authHeader !== apiSecretKey) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+  }
+
+  try {
+    const body = (await request.json().catch(() => ({}))) as {
+      date?: string
+    }
+
+    const result = await collectIvData(body.date)
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+    })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown error occurred'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/src/lib/__tests__/iv-collect.test.ts
+++ b/src/lib/__tests__/iv-collect.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { JQuantsOptionPrice } from '../jquants'
+
+// Mock dependencies
+vi.mock('../supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('../jquants-token', () => ({
+  getValidIdToken: vi.fn(),
+}))
+
+vi.mock('../jquants', () => ({
+  fetchOptionPrices: vi.fn(),
+}))
+
+import { supabase } from '../supabase'
+import { getValidIdToken } from '../jquants-token'
+import { fetchOptionPrices } from '../jquants'
+import {
+  filterAtmOptions,
+  buildIvHistoryRecords,
+  collectIvData,
+} from '../iv-collect'
+
+const mockedSupabase = vi.mocked(supabase)
+const mockedGetValidIdToken = vi.mocked(getValidIdToken)
+const mockedFetchOptionPrices = vi.mocked(fetchOptionPrices)
+
+// --- テストデータ ---
+
+function makeOptionPrice(overrides: Partial<JQuantsOptionPrice> = {}): JQuantsOptionPrice {
+  return {
+    Date: '2026-03-10',
+    Code: '130060018',
+    WholeDayOpen: 100,
+    WholeDayHigh: 110,
+    WholeDayLow: 90,
+    WholeDayClose: 105,
+    Volume: 500,
+    OpenInterest: 1000,
+    TurnoverValue: 50000000,
+    ContractMonth: '2026-04',
+    StrikePrice: 38000,
+    PutCallDivision: '2', // Call
+    ImpliedVolatility: 0.22,
+    UnderlyingPrice: 38000,
+    TheoreticalPrice: 500,
+    ...overrides,
+  }
+}
+
+describe('filterAtmOptions', () => {
+  it('ATM±2000円以内のオプションのみ抽出する', () => {
+    const options = [
+      makeOptionPrice({ StrikePrice: 36000, UnderlyingPrice: 38000 }), // -2000: 含む
+      makeOptionPrice({ StrikePrice: 37000, UnderlyingPrice: 38000 }), // -1000: 含む
+      makeOptionPrice({ StrikePrice: 38000, UnderlyingPrice: 38000 }), // ATM: 含む
+      makeOptionPrice({ StrikePrice: 39000, UnderlyingPrice: 38000 }), // +1000: 含む
+      makeOptionPrice({ StrikePrice: 40000, UnderlyingPrice: 38000 }), // +2000: 含む
+      makeOptionPrice({ StrikePrice: 41000, UnderlyingPrice: 38000 }), // +3000: 除外
+      makeOptionPrice({ StrikePrice: 35000, UnderlyingPrice: 38000 }), // -3000: 除外
+    ]
+
+    const result = filterAtmOptions(options)
+    expect(result).toHaveLength(5)
+    expect(result.map((o) => o.StrikePrice)).toEqual([36000, 37000, 38000, 39000, 40000])
+  })
+
+  it('IVがnullのオプションを除外する', () => {
+    const options = [
+      makeOptionPrice({ StrikePrice: 38000, UnderlyingPrice: 38000, ImpliedVolatility: null }),
+      makeOptionPrice({ StrikePrice: 38500, UnderlyingPrice: 38000, ImpliedVolatility: 0.25 }),
+    ]
+
+    const result = filterAtmOptions(options)
+    expect(result).toHaveLength(1)
+    expect(result[0].StrikePrice).toBe(38500)
+  })
+
+  it('UnderlyingPriceがnullのオプションを除外する', () => {
+    const options = [
+      makeOptionPrice({ StrikePrice: 38000, UnderlyingPrice: null }),
+    ]
+
+    const result = filterAtmOptions(options)
+    expect(result).toHaveLength(0)
+  })
+})
+
+describe('buildIvHistoryRecords', () => {
+  it('オプションデータからiv_historyレコードを構築する', () => {
+    const options = [
+      makeOptionPrice({
+        StrikePrice: 38000,
+        UnderlyingPrice: 38000,
+        ImpliedVolatility: 0.22,
+        PutCallDivision: '2', // Call
+        ContractMonth: '2026-04',
+      }),
+      makeOptionPrice({
+        StrikePrice: 38000,
+        UnderlyingPrice: 38000,
+        ImpliedVolatility: 0.24,
+        PutCallDivision: '1', // Put
+        ContractMonth: '2026-04',
+      }),
+    ]
+
+    const records = buildIvHistoryRecords(options)
+    expect(records).toHaveLength(2)
+
+    expect(records[0]).toMatchObject({
+      underlying_price: 38000,
+      strike_price: 38000,
+      option_type: 'call',
+      iv: 0.22,
+      data_source: 'j-quants',
+    })
+
+    expect(records[1]).toMatchObject({
+      underlying_price: 38000,
+      strike_price: 38000,
+      option_type: 'put',
+      iv: 0.24,
+      data_source: 'j-quants',
+    })
+  })
+
+  it('ContractMonthからexpiry_dateを設定する', () => {
+    const options = [
+      makeOptionPrice({ ContractMonth: '2026-04' }),
+    ]
+
+    const records = buildIvHistoryRecords(options)
+    // ContractMonth "2026-04" → expiry_date should be set
+    expect(records[0].expiry_date).toBeDefined()
+    expect(records[0].expiry_date).toContain('2026-04')
+  })
+
+  it('PutCallDivision "1"をput、"2"をcallに変換する', () => {
+    const putOption = makeOptionPrice({ PutCallDivision: '1' })
+    const callOption = makeOptionPrice({ PutCallDivision: '2' })
+
+    const records = buildIvHistoryRecords([putOption, callOption])
+    expect(records[0].option_type).toBe('put')
+    expect(records[1].option_type).toBe('call')
+  })
+})
+
+describe('collectIvData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('J-Quants APIからデータ取得しSupabaseに保存する', async () => {
+    mockedGetValidIdToken.mockResolvedValue('test-token')
+    mockedFetchOptionPrices.mockResolvedValue([
+      makeOptionPrice({
+        StrikePrice: 38000,
+        UnderlyingPrice: 38000,
+        ImpliedVolatility: 0.22,
+        PutCallDivision: '2',
+      }),
+    ])
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null, count: 1 })
+    const fromMock = vi.fn().mockReturnValue({ insert: insertMock })
+    mockedSupabase.from = fromMock
+
+    const result = await collectIvData()
+
+    expect(mockedGetValidIdToken).toHaveBeenCalledOnce()
+    expect(mockedFetchOptionPrices).toHaveBeenCalledWith('test-token', undefined)
+    expect(fromMock).toHaveBeenCalledWith('iv_history')
+    expect(insertMock).toHaveBeenCalledOnce()
+    expect(result.savedCount).toBe(1)
+  })
+
+  it('ATM範囲外のデータを除外して保存する', async () => {
+    mockedGetValidIdToken.mockResolvedValue('test-token')
+    mockedFetchOptionPrices.mockResolvedValue([
+      makeOptionPrice({ StrikePrice: 38000, UnderlyingPrice: 38000 }), // ATM
+      makeOptionPrice({ StrikePrice: 50000, UnderlyingPrice: 38000 }), // 除外
+    ])
+
+    const insertMock = vi.fn().mockResolvedValue({ error: null, count: 1 })
+    mockedSupabase.from = vi.fn().mockReturnValue({ insert: insertMock })
+
+    const result = await collectIvData()
+
+    // insertに渡されるレコードは1件のみ
+    const insertedRecords = insertMock.mock.calls[0][0]
+    expect(insertedRecords).toHaveLength(1)
+    expect(result.savedCount).toBe(1)
+  })
+
+  it('保存対象が0件の場合はinsertを呼ばない', async () => {
+    mockedGetValidIdToken.mockResolvedValue('test-token')
+    mockedFetchOptionPrices.mockResolvedValue([])
+
+    const insertMock = vi.fn()
+    mockedSupabase.from = vi.fn().mockReturnValue({ insert: insertMock })
+
+    const result = await collectIvData()
+
+    expect(insertMock).not.toHaveBeenCalled()
+    expect(result.savedCount).toBe(0)
+  })
+
+  it('Supabaseエラー時に例外を投げる', async () => {
+    mockedGetValidIdToken.mockResolvedValue('test-token')
+    mockedFetchOptionPrices.mockResolvedValue([
+      makeOptionPrice({ StrikePrice: 38000, UnderlyingPrice: 38000 }),
+    ])
+
+    const insertMock = vi.fn().mockResolvedValue({
+      error: { message: 'DB insert error' },
+      count: 0,
+    })
+    mockedSupabase.from = vi.fn().mockReturnValue({ insert: insertMock })
+
+    await expect(collectIvData()).rejects.toThrow('Failed to save IV data')
+  })
+
+  it('指定日付でデータ取得できる', async () => {
+    mockedGetValidIdToken.mockResolvedValue('test-token')
+    mockedFetchOptionPrices.mockResolvedValue([])
+
+    const insertMock = vi.fn()
+    mockedSupabase.from = vi.fn().mockReturnValue({ insert: insertMock })
+
+    await collectIvData('2026-03-10')
+
+    expect(mockedFetchOptionPrices).toHaveBeenCalledWith('test-token', '2026-03-10')
+  })
+})

--- a/src/lib/iv-collect.ts
+++ b/src/lib/iv-collect.ts
@@ -1,0 +1,104 @@
+/**
+ * IV データ蓄積ロジック
+ *
+ * J-Quants APIから取得したオプション価格データを
+ * ATM周辺でフィルタし、iv_historyテーブルに蓄積する。
+ */
+
+import type { JQuantsOptionPrice } from './jquants'
+import { fetchOptionPrices } from './jquants'
+import { getValidIdToken } from './jquants-token'
+import { supabase } from './supabase'
+
+// ATM周辺の範囲（±2000円）
+const ATM_RANGE = 2000
+
+export interface IvHistoryInsert {
+  recorded_at: string
+  underlying_price: number
+  strike_price: number
+  expiry_date: string
+  option_type: 'call' | 'put'
+  iv: number
+  data_source: string
+}
+
+export interface CollectIvDataResult {
+  savedCount: number
+  fetchedCount: number
+  filteredCount: number
+}
+
+/**
+ * ATM±2000円以内かつIV・原資産価格が有効なオプションを抽出する
+ */
+export function filterAtmOptions(
+  options: JQuantsOptionPrice[],
+): JQuantsOptionPrice[] {
+  return options.filter((opt) => {
+    if (opt.UnderlyingPrice == null || opt.ImpliedVolatility == null) {
+      return false
+    }
+    const distance = Math.abs(opt.StrikePrice - opt.UnderlyingPrice)
+    return distance <= ATM_RANGE
+  })
+}
+
+/**
+ * J-Quantsオプション価格データからiv_historyレコードを構築する
+ */
+export function buildIvHistoryRecords(
+  options: JQuantsOptionPrice[],
+): IvHistoryInsert[] {
+  const now = new Date().toISOString()
+
+  return options.map((opt) => {
+    const optionType = opt.PutCallDivision === '1' ? 'put' : 'call'
+
+    // ContractMonth "2026-04" → "2026-04-01" (月初を仮の限月日とする)
+    const expiryDate = `${opt.ContractMonth}-01`
+
+    return {
+      recorded_at: now,
+      underlying_price: opt.UnderlyingPrice!,
+      strike_price: opt.StrikePrice,
+      expiry_date: expiryDate,
+      option_type: optionType,
+      iv: opt.ImpliedVolatility!,
+      data_source: 'j-quants',
+    }
+  })
+}
+
+/**
+ * J-Quants APIからIVデータを取得し、iv_historyテーブルに蓄積する
+ *
+ * @param date - 取得日（YYYY-MM-DD形式）。省略時は直近営業日
+ * @returns 蓄積結果
+ */
+export async function collectIvData(
+  date?: string,
+): Promise<CollectIvDataResult> {
+  const idToken = await getValidIdToken()
+  const allOptions = await fetchOptionPrices(idToken, date)
+
+  const atmOptions = filterAtmOptions(allOptions)
+
+  if (atmOptions.length === 0) {
+    return { savedCount: 0, fetchedCount: allOptions.length, filteredCount: 0 }
+  }
+
+  const records = buildIvHistoryRecords(atmOptions)
+
+  const { error } = await supabase.from('iv_history').insert(records)
+
+  if (error) {
+    throw new Error(`Failed to save IV data: ${error.message}`)
+  }
+
+  return {
+    savedCount: records.length,
+    fetchedCount: allOptions.length,
+    filteredCount: atmOptions.length,
+  }
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -25,6 +25,25 @@ export interface Trade {
   entry_vega: number | null
 }
 
+export type OptionType = 'call' | 'put'
+
+export interface IvHistory {
+  id: string
+  recorded_at: string
+  underlying_price: number
+  strike_price: number
+  expiry_date: string
+  option_type: OptionType
+  iv: number
+  iv_rank: number | null
+  iv_percentile: number | null
+  hv20: number | null
+  hv60: number | null
+  nikkei_vi: number | null
+  pcr: number | null
+  data_source: string
+}
+
 export interface JQuantsToken {
   id: string
   refresh_token: string
@@ -48,6 +67,12 @@ export type Database = {
         Row: JQuantsToken
         Insert: Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>
         Update: Partial<Omit<JQuantsToken, 'id' | 'created_at' | 'updated_at'>>
+        Relationships: []
+      }
+      iv_history: {
+        Row: IvHistory
+        Insert: Omit<IvHistory, 'id'>
+        Update: Partial<Omit<IvHistory, 'id'>>
         Relationships: []
       }
     }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -63,3 +63,31 @@ create table if not exists j_quants_tokens (
 create trigger j_quants_tokens_updated_at
   before update on j_quants_tokens
   for each row execute function update_updated_at();
+
+-- =============================================
+-- IVキャッシュテーブル（Phase 2用）
+-- =============================================
+create table if not exists iv_history (
+  id uuid primary key default gen_random_uuid(),
+  recorded_at timestamptz not null default now(),
+  underlying_price numeric(10, 2) not null,
+  strike_price integer not null,
+  expiry_date date not null,
+  option_type text not null check (option_type in ('call', 'put')),
+  iv numeric(8, 4) not null,
+  iv_rank numeric(5, 2),
+  iv_percentile numeric(5, 2),
+  hv20 numeric(8, 4),
+  hv60 numeric(8, 4),
+  nikkei_vi numeric(6, 2),
+  pcr numeric(6, 3),
+  data_source text not null
+);
+
+-- インデックス
+create index if not exists iv_history_recorded_at_idx on iv_history (recorded_at desc);
+create index if not exists iv_history_strike_expiry_idx on iv_history (strike_price, expiry_date);
+create index if not exists iv_history_option_type_idx on iv_history (option_type);
+
+-- RLS（Phase 4で有効化）
+alter table iv_history enable row level security;


### PR DESCRIPTION
## Summary
- `supabase/schema.sql` に `iv_history` テーブル定義・インデックスを追加
- `src/lib/iv-collect.ts` にATM±2000円フィルタ・レコード構築・蓄積ロジックを実装
- `src/app/api/iv-data/collect/route.ts` にデータ蓄積APIルートを新規作成
- `src/types/database.ts` に `IvHistory` 型定義を追加

## Test plan
- [x] ATM±2000円以内のオプションのみ抽出されること（filterAtmOptions）
- [x] IV/UnderlyingPriceがnullのオプションが除外されること
- [x] PutCallDivisionが正しくcall/putに変換されること
- [x] Supabaseへの保存が正常に行われること
- [x] 保存対象0件の場合insertが呼ばれないこと
- [x] Supabaseエラー時に例外が投げられること
- [x] 指定日付でのデータ取得が動作すること
- [x] 既存テスト（trade.test.ts）が壊れていないこと（全17テストpass）

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)