### PR TITLE
feat: CSVエクスポート機能 (#25)

### DIFF
--- a/src/app/api/trades/export/route.ts
+++ b/src/app/api/trades/export/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { generateCsv } from '@/lib/csv-export'
+import type { Trade } from '@/types/database'
+
+export async function GET() {
+  const { data, error } = await supabase
+    .from('trades')
+    .select('*')
+    .order('trade_date', { ascending: false })
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'Failed to fetch trades' },
+      { status: 500 }
+    )
+  }
+
+  const trades = (data ?? []) as Trade[]
+  const csv = generateCsv(trades)
+
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': 'attachment; filename="trades.csv"',
+    },
+  })
+}

--- a/src/app/trades/page.tsx
+++ b/src/app/trades/page.tsx
@@ -30,12 +30,23 @@ export default async function TradesPage() {
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold text-white">売買履歴</h1>
-          <Link
-            href="/trades/new"
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors"
-          >
-            + 新規記録
-          </Link>
+          <div className="flex items-center gap-2">
+            {trades.length > 0 && (
+              <a
+                href="/api/trades/export"
+                download="trades.csv"
+                className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium rounded-xl transition-colors"
+              >
+                CSVエクスポート
+              </a>
+            )}
+            <Link
+              href="/trades/new"
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors"
+            >
+              + 新規記録
+            </Link>
+          </div>
         </div>
 
         {/* Stats */}

--- a/src/lib/__tests__/csv-export.test.ts
+++ b/src/lib/__tests__/csv-export.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { generateCsv, CSV_HEADERS } from '../csv-export'
+import type { Trade } from '@/types/database'
+
+const baseTrade: Trade = {
+  id: '1',
+  user_id: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  trade_date: '2024-01-15',
+  trade_type: 'call',
+  strike_price: 33000,
+  expiry_date: '2024-02-09',
+  quantity: 2,
+  entry_price: 150,
+  exit_price: 200,
+  exit_date: '2024-01-20',
+  pnl: 100000,
+  iv_at_entry: 18.5,
+  memo: 'テストメモ',
+  status: 'closed',
+  defeat_tags: ['損切り遅れ'],
+  entry_delta: 0.3,
+  entry_gamma: 0.01,
+  entry_theta: -5.0,
+  entry_vega: 10.0,
+}
+
+describe('CSV_HEADERS', () => {
+  it('必要なヘッダーがすべて含まれている', () => {
+    expect(CSV_HEADERS).toEqual([
+      '取引ID',
+      '取引日',
+      '種別',
+      '権利行使価格',
+      '限月',
+      '枚数',
+      '購入価格',
+      '決済価格',
+      '決済日',
+      '損益',
+      'ステータス',
+      'IV',
+      'エントリー理由',
+      '敗因タグ',
+    ])
+  })
+})
+
+describe('generateCsv', () => {
+  it('UTF-8 BOM付きでCSVを生成する', () => {
+    const csv = generateCsv([baseTrade])
+    expect(csv.startsWith('\uFEFF')).toBe(true)
+  })
+
+  it('ヘッダー行が正しい', () => {
+    const csv = generateCsv([baseTrade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[0]).toBe(CSV_HEADERS.join(','))
+  })
+
+  it('取引データが正しくCSV行に変換される', () => {
+    const csv = generateCsv([baseTrade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[1]).toBe(
+      '1,2024-01-15,call,33000,2024-02-09,2,150,200,2024-01-20,100000,closed,18.5,テストメモ,損切り遅れ'
+    )
+  })
+
+  it('null値は空文字として出力される', () => {
+    const trade: Trade = {
+      ...baseTrade,
+      exit_price: null,
+      exit_date: null,
+      pnl: null,
+      iv_at_entry: null,
+      memo: null,
+      defeat_tags: null,
+    }
+    const csv = generateCsv([trade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[1]).toBe(
+      '1,2024-01-15,call,33000,2024-02-09,2,150,,,,closed,,,'
+    )
+  })
+
+  it('カンマを含むフィールドはダブルクォートで囲まれる', () => {
+    const trade: Trade = {
+      ...baseTrade,
+      memo: 'IV高め,エントリー',
+    }
+    const csv = generateCsv([trade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[1]).toContain('"IV高め,エントリー"')
+  })
+
+  it('ダブルクォートを含むフィールドはエスケープされる', () => {
+    const trade: Trade = {
+      ...baseTrade,
+      memo: 'テスト"メモ',
+    }
+    const csv = generateCsv([trade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[1]).toContain('"テスト""メモ"')
+  })
+
+  it('改行を含むフィールドはダブルクォートで囲まれる', () => {
+    const trade: Trade = {
+      ...baseTrade,
+      memo: 'テスト\nメモ',
+    }
+    const csv = generateCsv([trade])
+    const dataContent = csv.replace('\uFEFF', '')
+    expect(dataContent).toContain('"テスト\nメモ"')
+  })
+
+  it('空配列の場合はヘッダーのみ出力される', () => {
+    const csv = generateCsv([])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[0]).toBe(CSV_HEADERS.join(','))
+    // Only header + trailing empty from final \r\n
+    expect(lines.filter((l) => l.length > 0)).toHaveLength(1)
+  })
+
+  it('複数取引が正しく出力される', () => {
+    const trade2: Trade = {
+      ...baseTrade,
+      id: '2',
+      trade_type: 'put',
+      strike_price: 32000,
+    }
+    const csv = generateCsv([baseTrade, trade2])
+    const lines = csv.replace('\uFEFF', '').split('\r\n').filter((l) => l.length > 0)
+    expect(lines).toHaveLength(3) // header + 2 data rows
+  })
+
+  it('defeat_tagsが複数ある場合はセミコロン区切りで出力される', () => {
+    const trade: Trade = {
+      ...baseTrade,
+      defeat_tags: ['損切り遅れ', 'IV読み違い'],
+    }
+    const csv = generateCsv([trade])
+    const lines = csv.replace('\uFEFF', '').split('\r\n')
+    expect(lines[1]).toContain('損切り遅れ;IV読み違い')
+  })
+})

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -1,0 +1,52 @@
+import type { Trade } from '@/types/database'
+
+export const CSV_HEADERS = [
+  '取引ID',
+  '取引日',
+  '種別',
+  '権利行使価格',
+  '限月',
+  '枚数',
+  '購入価格',
+  '決済価格',
+  '決済日',
+  '損益',
+  'ステータス',
+  'IV',
+  'エントリー理由',
+  '敗因タグ',
+] as const
+
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+function tradeToRow(trade: Trade): string {
+  const fields: string[] = [
+    trade.id,
+    trade.trade_date,
+    trade.trade_type,
+    String(trade.strike_price),
+    trade.expiry_date,
+    String(trade.quantity),
+    String(trade.entry_price),
+    trade.exit_price !== null ? String(trade.exit_price) : '',
+    trade.exit_date ?? '',
+    trade.pnl !== null ? String(trade.pnl) : '',
+    trade.status,
+    trade.iv_at_entry !== null ? String(trade.iv_at_entry) : '',
+    trade.memo ?? '',
+    trade.defeat_tags ? trade.defeat_tags.join(';') : '',
+  ]
+  return fields.map(escapeCsvField).join(',')
+}
+
+export function generateCsv(trades: Trade[]): string {
+  const BOM = '\uFEFF'
+  const header = CSV_HEADERS.join(',')
+  const rows = trades.map(tradeToRow)
+  return BOM + [header, ...rows].join('\r\n') + '\r\n'
+}


### PR DESCRIPTION
## Summary
- CSV生成ユーティリティを新規追加（UTF-8 BOM付きでExcel対応、カンマ・改行・ダブルクォートのエスケープ処理）
- `GET /api/trades/export` APIルートで全取引データをCSVダウンロード
- 売買履歴ページに「CSVエクスポート」ボタンを追加（取引データがある場合のみ表示）

## Test plan
- [x] CSVヘッダーが仕様通りであること
- [x] UTF-8 BOM付きで生成されること（Excel対応）
- [x] 特殊文字（カンマ・改行・ダブルクォート）が正しくエスケープされること
- [x] null値が空文字として出力されること
- [x] 空データ時にヘッダーのみ出力されること
- [x] 複数取引・defeat_tagsのセミコロン区切りが正しいこと
- [x] 全123テストがパス

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)