### PR TITLE
feat: RLSポリシー有効化

### DIFF
--- a/src/lib/__tests__/rls-policies.test.ts
+++ b/src/lib/__tests__/rls-policies.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const schemaSQL = readFileSync(
+  join(process.cwd(), 'supabase/schema.sql'),
+  'utf-8'
+)
+
+describe('RLSポリシー定義（supabase/schema.sql）', () => {
+  describe('tradesテーブル', () => {
+    it('RLSが有効化されている', () => {
+      expect(schemaSQL).toContain('alter table trades enable row level security')
+    })
+
+    it('SELECTポリシーが定義されている（自分のトレードのみ参照可能）', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on trades[\s\S]*?for select/i)
+      expect(schemaSQL).toContain('auth.uid() = user_id')
+    })
+
+    it('INSERTポリシーが定義されている', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on trades[\s\S]*?for insert/i)
+    })
+
+    it('UPDATEポリシーが定義されている', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on trades[\s\S]*?for update/i)
+    })
+
+    it('DELETEポリシーが定義されている', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on trades[\s\S]*?for delete/i)
+    })
+  })
+
+  describe('iv_historyテーブル', () => {
+    it('RLSが有効化されている', () => {
+      expect(schemaSQL).toContain('alter table iv_history enable row level security')
+    })
+
+    it('SELECTポリシーが定義されている（全員参照可能）', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on iv_history[\s\S]*?for select/i)
+    })
+  })
+
+  describe('user_preferencesテーブル', () => {
+    it('RLSが有効化されている', () => {
+      expect(schemaSQL).toContain('alter table user_preferences enable row level security')
+    })
+
+    it('SELECTポリシーが定義されている', () => {
+      expect(schemaSQL).toMatch(/create policy[\s\S]*?on user_preferences[\s\S]*?for select/i)
+    })
+  })
+})

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -44,10 +44,22 @@ create index if not exists trades_trade_date_idx on trades (trade_date desc);
 create index if not exists trades_status_idx on trades (status);
 create index if not exists trades_user_id_idx on trades (user_id);
 
--- RLS（Phase 4で有効化）
+-- RLS
 alter table trades enable row level security;
--- Phase 4でのポリシー追加例:
--- create policy "Users can only see own trades" on trades for select using (auth.uid() = user_id);
+
+-- trades RLSポリシー: ユーザーは自分のトレードのみ操作可能
+create policy "Users can select own trades" on trades
+  for select using (auth.uid() = user_id);
+
+create policy "Users can insert own trades" on trades
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can update own trades" on trades
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own trades" on trades
+  for delete using (auth.uid() = user_id);
 
 -- =============================================
 -- J-Quants API トークン管理テーブル
@@ -92,8 +104,12 @@ create index if not exists iv_history_recorded_at_idx on iv_history (recorded_at
 create index if not exists iv_history_strike_expiry_idx on iv_history (strike_price, expiry_date);
 create index if not exists iv_history_option_type_idx on iv_history (option_type);
 
--- RLS（Phase 4で有効化）
+-- RLS
 alter table iv_history enable row level security;
+
+-- iv_history RLSポリシー: 全ユーザーが参照可能（書き込みはサービスロールのみ）
+create policy "Anyone can select iv_history" on iv_history
+  for select using (true);
 
 -- =============================================
 -- Web Push購読管理テーブル
@@ -134,5 +150,16 @@ create trigger user_preferences_updated_at
 -- インデックス
 create index if not exists user_preferences_user_id_idx on user_preferences (user_id);
 
--- RLS（Phase 4で有効化）
+-- RLS
 alter table user_preferences enable row level security;
+
+-- user_preferences RLSポリシー: ユーザーは自分の設定のみ操作可能
+create policy "Users can select own preferences" on user_preferences
+  for select using (auth.uid() = user_id);
+
+create policy "Users can insert own preferences" on user_preferences
+  for insert with check (auth.uid() = user_id);
+
+create policy "Users can update own preferences" on user_preferences
+  for update using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Related Issue
Closes #27

## Summary
- trades テーブル: SELECT/INSERT/UPDATE/DELETE を `auth.uid() = user_id` で制限
- iv_history テーブル: SELECT 全員可（書き込みはサービスロールのみ）
- user_preferences テーブル: SELECT/INSERT/UPDATE を `auth.uid() = user_id` で制限

## Test plan
- [x] RLSポリシー定義の存在確認テスト9件追加
- [x] 全213テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)