### PR TITLE
feat: UI刷新 - 証券アプリ風ダークテーマ

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -63,78 +63,75 @@ export default async function AnalyticsPage() {
   const maxDefeatCount = defeatTagsWithCount.length > 0 ? defeatTagsWithCount[0].count : 0
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-4xl mx-auto">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors"
-        >
-          &larr; ホーム
-        </Link>
-        <h1 className="text-2xl font-bold text-slate-100 mb-2">分析ダッシュボード</h1>
-        <p className="text-slate-500 mb-8">トレード分析・敗因タグ・市場環境タグの集計</p>
+        {/* Header */}
+        <div className="py-4">
+          <h1 className="text-lg font-bold text-white">分析ダッシュボード</h1>
+          <p className="text-[10px] text-[#666] mt-0.5">トレード分析・敗因タグ・市場環境タグの集計</p>
+        </div>
 
-        {/* サマリー */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4 text-center">
-            <div className="text-xs text-slate-500 mb-1">決済済み取引</div>
-            <div className="text-2xl font-bold text-slate-100">{totalTrades}</div>
+        {/* Summary Stats */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3 text-center">
+            <div className="text-[10px] text-[#888] mb-0.5">決済済み取引</div>
+            <div className="text-xl font-bold text-white">{totalTrades}</div>
           </div>
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4 text-center">
-            <div className="text-xs text-slate-500 mb-1">勝ち</div>
-            <div className="text-2xl font-bold text-green-400">{wins}</div>
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3 text-center">
+            <div className="text-[10px] text-[#888] mb-0.5">勝ち</div>
+            <div className="text-xl font-bold text-[#00d4aa]">{wins}</div>
           </div>
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4 text-center">
-            <div className="text-xs text-slate-500 mb-1">負け</div>
-            <div className="text-2xl font-bold text-red-400">{losses}</div>
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3 text-center">
+            <div className="text-[10px] text-[#888] mb-0.5">負け</div>
+            <div className="text-xl font-bold text-[#ff6b6b]">{losses}</div>
           </div>
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4 text-center">
-            <div className="text-xs text-slate-500 mb-1">勝率</div>
-            <div className="text-2xl font-bold text-slate-100">{winRate}%</div>
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3 text-center">
+            <div className="text-[10px] text-[#888] mb-0.5">勝率</div>
+            <div className="text-xl font-bold text-white">{winRate}%</div>
           </div>
         </div>
 
         <PnlChart data={chartData} />
 
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold text-slate-100 mb-4">
-            勝率 × IVランク相関分析
+        <section className="mb-6">
+          <h2 className="text-sm font-semibold text-white mb-3">
+            勝率 x IVランク相関分析
           </h2>
           <IvRankAnalysis trades={trades} />
         </section>
 
-        <section className="mb-8">
+        <section className="mb-6">
           <VolatilitySkewChart data={skewTimeSeries} />
         </section>
 
         {totalTrades === 0 ? (
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-12 text-center">
-            <p className="text-slate-400">決済済みの取引がまだありません</p>
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-12 text-center">
+            <p className="text-[#555]">決済済みの取引がまだありません</p>
           </div>
         ) : (
           <>
-            {/* 敗因タグ集計 */}
-            <section className="mb-8">
-              <h2 className="text-lg font-semibold text-slate-100 mb-4">敗因タグ集計</h2>
+            {/* Defeat Tags Table */}
+            <section className="mb-6">
+              <h2 className="text-sm font-semibold text-white mb-3">敗因タグ集計</h2>
               {defeatTagsWithCount.length === 0 ? (
-                <div className="bg-slate-900 border border-slate-800 rounded-2xl p-8 text-center">
-                  <p className="text-slate-400">敗因タグが設定された取引がありません</p>
+                <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-8 text-center">
+                  <p className="text-[#555]">敗因タグが設定された取引がありません</p>
                 </div>
               ) : (
-                <div className="bg-slate-900 border border-slate-800 rounded-2xl overflow-hidden">
+                <div className="bg-[#111] border border-[#1e1e1e] rounded-xl overflow-hidden">
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="border-b border-slate-800">
-                        <th className="text-left text-xs text-slate-500 font-medium px-4 py-3">
+                      <tr className="border-b border-[#1e1e1e]">
+                        <th className="text-left text-[10px] text-[#00d4aa]/70 font-medium px-4 py-2.5">
                           敗因タグ
                         </th>
-                        <th className="text-right text-xs text-slate-500 font-medium px-4 py-3">
+                        <th className="text-right text-[10px] text-[#00d4aa]/70 font-medium px-4 py-2.5">
                           回数
                         </th>
-                        <th className="text-right text-xs text-slate-500 font-medium px-4 py-3">
+                        <th className="text-right text-[10px] text-[#00d4aa]/70 font-medium px-4 py-2.5">
                           損失合計
                         </th>
-                        <th className="text-left text-xs text-slate-500 font-medium px-4 py-3 hidden sm:table-cell">
+                        <th className="text-left text-[10px] text-[#00d4aa]/70 font-medium px-4 py-2.5 hidden sm:table-cell">
                           割合
                         </th>
                       </tr>
@@ -146,19 +143,19 @@ export default async function AnalyticsPage() {
                         return (
                           <tr
                             key={item.tag}
-                            className="border-b border-slate-800/50 last:border-0"
+                            className="border-b border-[#1e1e1e]/50 last:border-0"
                           >
-                            <td className="px-4 py-3 text-slate-200">{item.tag}</td>
-                            <td className="px-4 py-3 text-right text-slate-300 font-mono">
+                            <td className="px-4 py-2.5 text-[#ccc]">{item.tag}</td>
+                            <td className="px-4 py-2.5 text-right text-[#888] font-mono">
                               {item.count}
                             </td>
-                            <td className="px-4 py-3 text-right text-red-400 font-mono">
+                            <td className="px-4 py-2.5 text-right text-[#ff6b6b] font-mono">
                               {item.totalLoss.toLocaleString()}円
                             </td>
-                            <td className="px-4 py-3 hidden sm:table-cell">
-                              <div className="w-full bg-slate-800 rounded-full h-2">
+                            <td className="px-4 py-2.5 hidden sm:table-cell">
+                              <div className="w-full bg-[#1a1a1a] rounded-full h-1.5">
                                 <div
-                                  className="bg-red-500 h-2 rounded-full"
+                                  className="bg-[#ff6b6b] h-1.5 rounded-full"
                                   style={{ width: `${ratio}%` }}
                                 />
                               </div>
@@ -172,12 +169,12 @@ export default async function AnalyticsPage() {
               )}
             </section>
 
-            {/* 敗因カテゴリ別サマリー */}
-            <section className="mb-8">
-              <h2 className="text-lg font-semibold text-slate-100 mb-4">
+            {/* Defeat Category Summary */}
+            <section className="mb-6">
+              <h2 className="text-sm font-semibold text-white mb-3">
                 敗因カテゴリ別サマリー
               </h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
                 {Object.entries(DEFEAT_TAG_CATEGORIES).map(([category, tags]) => {
                   const categoryTotal = tags.reduce((sum, tag) => {
                     const found = defeatAgg.find((d) => d.tag === tag)
@@ -190,12 +187,12 @@ export default async function AnalyticsPage() {
                   return (
                     <div
                       key={category}
-                      className="bg-slate-900 border border-slate-800 rounded-2xl p-4"
+                      className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3"
                     >
-                      <div className="text-xs text-slate-500 mb-1">{category}</div>
-                      <div className="text-xl font-bold text-slate-100">{categoryTotal}回</div>
+                      <div className="text-[10px] text-[#888] mb-0.5">{category}</div>
+                      <div className="text-lg font-bold text-white">{categoryTotal}回</div>
                       {categoryLoss < 0 && (
-                        <div className="text-sm text-red-400 font-mono">
+                        <div className="text-xs text-[#ff6b6b] font-mono">
                           {categoryLoss.toLocaleString()}円
                         </div>
                       )}
@@ -205,42 +202,42 @@ export default async function AnalyticsPage() {
               </div>
             </section>
 
-            {/* 市場環境タグ×勝率ヒートマップ */}
-            <section className="mb-8">
-              <h2 className="text-lg font-semibold text-slate-100 mb-4">
-                市場環境×勝率ヒートマップ
+            {/* Market Env Heatmap */}
+            <section className="mb-6">
+              <h2 className="text-sm font-semibold text-white mb-3">
+                市場環境 x 勝率ヒートマップ
               </h2>
-              <div className="space-y-4">
+              <div className="space-y-3">
                 {Object.entries(MARKET_ENV_AXES).map(([axis, config]) => (
                   <div
                     key={axis}
-                    className="bg-slate-900 border border-slate-800 rounded-2xl p-4"
+                    className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3"
                   >
-                    <div className="text-xs text-slate-500 mb-3 font-medium">{config.label}</div>
-                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+                    <div className="text-[10px] text-[#00d4aa]/70 mb-2 font-medium">{config.label}</div>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-1.5">
                       {config.tags.map((tag) => {
                         const data = marketEnvAgg.find((m) => m.tag === tag)
                         const winRate = data?.winRate ?? 0
                         const total = data?.total ?? 0
-                        let bgColor = 'bg-slate-800'
+                        let bgColor = 'bg-[#1a1a1a]'
                         if (total > 0) {
-                          if (winRate >= 70) bgColor = 'bg-green-900/60 border-green-700/50'
-                          else if (winRate >= 50) bgColor = 'bg-emerald-900/40 border-emerald-700/30'
-                          else if (winRate >= 30) bgColor = 'bg-yellow-900/40 border-yellow-700/30'
-                          else bgColor = 'bg-red-900/40 border-red-700/30'
+                          if (winRate >= 70) bgColor = 'bg-[#00d4aa]/15 border-[#00d4aa]/20'
+                          else if (winRate >= 50) bgColor = 'bg-[#00d4aa]/8 border-[#00d4aa]/10'
+                          else if (winRate >= 30) bgColor = 'bg-[#f0b429]/10 border-[#f0b429]/15'
+                          else bgColor = 'bg-[#ff6b6b]/10 border-[#ff6b6b]/15'
                         }
                         return (
                           <div
                             key={tag}
-                            className={`${bgColor} border border-slate-700/50 rounded-xl p-3 text-center`}
+                            className={`${bgColor} border border-[#2a2a2a] rounded-lg p-2.5 text-center`}
                           >
-                            <div className="text-xs text-slate-400 mb-1 truncate" title={tag}>
+                            <div className="text-[10px] text-[#888] mb-0.5 truncate" title={tag}>
                               {tag}
                             </div>
-                            <div className="text-lg font-bold text-slate-100">
+                            <div className="text-base font-bold text-white">
                               {total > 0 ? `${winRate.toFixed(0)}%` : '-'}
                             </div>
-                            <div className="text-xs text-slate-500">
+                            <div className="text-[10px] text-[#555]">
                               {total > 0
                                 ? `${data!.wins}勝${data!.losses}敗`
                                 : 'データなし'}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,11 +1,19 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { createBrowserSupabaseClient } from '@/lib/supabase/client'
 
 export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  )
+}
+
+function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const redirectTo = searchParams.get('redirectTo') || '/'
@@ -37,20 +45,22 @@ export default function LoginPage() {
     <main className="min-h-screen flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
-          <span className="text-blue-400 text-3xl">◈</span>
-          <h1 className="text-2xl font-bold text-white mt-2">ログイン</h1>
-          <p className="text-sm text-slate-400 mt-1">NK225 Options</p>
+          <div className="w-12 h-12 bg-[#00d4aa] rounded-xl flex items-center justify-center mx-auto mb-3">
+            <span className="text-black text-xl font-bold">N</span>
+          </div>
+          <h1 className="text-xl font-bold text-white mt-2">ログイン</h1>
+          <p className="text-xs text-[#666] mt-1">NK225 Options</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-3 text-sm text-red-400">
+            <div className="bg-[#ff6b6b]/10 border border-[#ff6b6b]/20 rounded-lg px-3 py-2.5 text-sm text-[#ff6b6b]">
               {error}
             </div>
           )}
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-slate-300 mb-1">
+            <label htmlFor="email" className="block text-[10px] font-medium text-[#00d4aa]/70 mb-1 uppercase tracking-wider">
               メールアドレス
             </label>
             <input
@@ -59,13 +69,13 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-3 py-2 bg-slate-900 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2.5 bg-[#111] border border-[#2a2a2a] rounded-lg text-white placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa]"
               placeholder="email@example.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-slate-300 mb-1">
+            <label htmlFor="password" className="block text-[10px] font-medium text-[#00d4aa]/70 mb-1 uppercase tracking-wider">
               パスワード
             </label>
             <input
@@ -75,7 +85,7 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="w-full px-3 py-2 bg-slate-900 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2.5 bg-[#111] border border-[#2a2a2a] rounded-lg text-white placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa]"
               placeholder="6文字以上"
             />
           </div>
@@ -83,15 +93,15 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
+            className="w-full py-2.5 bg-[#00d4aa] hover:bg-[#00c49a] disabled:opacity-50 disabled:cursor-not-allowed text-black font-medium rounded-lg transition-colors"
           >
             {loading ? 'ログイン中...' : 'ログイン'}
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-xs text-[#555]">
           アカウントをお持ちでない方は{' '}
-          <Link href="/auth/signup" className="text-blue-400 hover:text-blue-300">
+          <Link href="/auth/signup" className="text-[#00d4aa] hover:opacity-80">
             新規登録
           </Link>
         </p>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -36,14 +36,16 @@ export default function SignupPage() {
     return (
       <main className="min-h-screen flex items-center justify-center px-4">
         <div className="w-full max-w-sm text-center">
-          <span className="text-blue-400 text-3xl">◈</span>
-          <h1 className="text-2xl font-bold text-white mt-2 mb-4">確認メールを送信しました</h1>
-          <p className="text-sm text-slate-400 mb-6">
+          <div className="w-12 h-12 bg-[#00d4aa] rounded-xl flex items-center justify-center mx-auto mb-3">
+            <span className="text-black text-xl font-bold">N</span>
+          </div>
+          <h1 className="text-xl font-bold text-white mt-2 mb-4">確認メールを送信しました</h1>
+          <p className="text-xs text-[#666] mb-6">
             {email} に確認メールを送信しました。メール内のリンクをクリックして登録を完了してください。
           </p>
           <Link
             href="/auth/login"
-            className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition-colors"
+            className="inline-block px-4 py-2 bg-[#00d4aa] hover:bg-[#00c49a] text-black font-medium rounded-lg transition-colors"
           >
             ログインページへ
           </Link>
@@ -56,20 +58,22 @@ export default function SignupPage() {
     <main className="min-h-screen flex items-center justify-center px-4">
       <div className="w-full max-w-sm">
         <div className="text-center mb-8">
-          <span className="text-blue-400 text-3xl">◈</span>
-          <h1 className="text-2xl font-bold text-white mt-2">新規登録</h1>
-          <p className="text-sm text-slate-400 mt-1">NK225 Options</p>
+          <div className="w-12 h-12 bg-[#00d4aa] rounded-xl flex items-center justify-center mx-auto mb-3">
+            <span className="text-black text-xl font-bold">N</span>
+          </div>
+          <h1 className="text-xl font-bold text-white mt-2">新規登録</h1>
+          <p className="text-xs text-[#666] mt-1">NK225 Options</p>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-3 text-sm text-red-400">
+            <div className="bg-[#ff6b6b]/10 border border-[#ff6b6b]/20 rounded-lg px-3 py-2.5 text-sm text-[#ff6b6b]">
               {error}
             </div>
           )}
 
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-slate-300 mb-1">
+            <label htmlFor="email" className="block text-[10px] font-medium text-[#00d4aa]/70 mb-1 uppercase tracking-wider">
               メールアドレス
             </label>
             <input
@@ -78,13 +82,13 @@ export default function SignupPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              className="w-full px-3 py-2 bg-slate-900 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2.5 bg-[#111] border border-[#2a2a2a] rounded-lg text-white placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa]"
               placeholder="email@example.com"
             />
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-slate-300 mb-1">
+            <label htmlFor="password" className="block text-[10px] font-medium text-[#00d4aa]/70 mb-1 uppercase tracking-wider">
               パスワード
             </label>
             <input
@@ -94,7 +98,7 @@ export default function SignupPage() {
               onChange={(e) => setPassword(e.target.value)}
               required
               minLength={6}
-              className="w-full px-3 py-2 bg-slate-900 border border-slate-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2.5 bg-[#111] border border-[#2a2a2a] rounded-lg text-white placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa]"
               placeholder="6文字以上"
             />
           </div>
@@ -102,15 +106,15 @@ export default function SignupPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors"
+            className="w-full py-2.5 bg-[#00d4aa] hover:bg-[#00c49a] disabled:opacity-50 disabled:cursor-not-allowed text-black font-medium rounded-lg transition-colors"
           >
             {loading ? '登録中...' : '新規登録'}
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-slate-400">
+        <p className="mt-6 text-center text-xs text-[#555]">
           既にアカウントをお持ちの方は{' '}
-          <Link href="/auth/login" className="text-blue-400 hover:text-blue-300">
+          <Link href="/auth/login" className="text-[#00d4aa] hover:opacity-80">
             ログイン
           </Link>
         </p>

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -8,20 +8,20 @@ const categoryConfig: Record<
   EventCategory,
   { color: string; dot: string; label: string }
 > = {
-  sq: { color: 'text-red-400', dot: 'bg-red-400', label: 'SQ日' },
-  fomc: { color: 'text-blue-400', dot: 'bg-blue-400', label: 'FOMC' },
-  fomc_press: { color: 'text-blue-300', dot: 'bg-blue-300', label: 'FRB記者会見' },
-  boj: { color: 'text-purple-400', dot: 'bg-purple-400', label: '日銀会合' },
-  boj_press: { color: 'text-purple-300', dot: 'bg-purple-300', label: '日銀記者会見' },
-  ecb_press: { color: 'text-pink-400', dot: 'bg-pink-400', label: 'ECB記者会見' },
-  employment: { color: 'text-green-400', dot: 'bg-green-400', label: '米雇用統計' },
-  cpi: { color: 'text-yellow-400', dot: 'bg-yellow-400', label: 'CPI' },
-  gdp: { color: 'text-cyan-400', dot: 'bg-cyan-400', label: 'GDP' },
-  pce: { color: 'text-amber-400', dot: 'bg-amber-400', label: 'PCE' },
-  ism: { color: 'text-teal-400', dot: 'bg-teal-400', label: 'ISM' },
-  tankan: { color: 'text-indigo-400', dot: 'bg-indigo-400', label: '短観' },
-  earnings: { color: 'text-orange-400', dot: 'bg-orange-400', label: '決算' },
-  other: { color: 'text-slate-400', dot: 'bg-slate-400', label: 'その他' },
+  sq: { color: 'text-[#ff6b6b]', dot: 'bg-[#ff6b6b]', label: 'SQ日' },
+  fomc: { color: 'text-[#4da6ff]', dot: 'bg-[#4da6ff]', label: 'FOMC' },
+  fomc_press: { color: 'text-[#6db8ff]', dot: 'bg-[#6db8ff]', label: 'FRB記者会見' },
+  boj: { color: 'text-[#b48cff]', dot: 'bg-[#b48cff]', label: '日銀会合' },
+  boj_press: { color: 'text-[#c9a5ff]', dot: 'bg-[#c9a5ff]', label: '日銀記者会見' },
+  ecb_press: { color: 'text-[#ff7eb3]', dot: 'bg-[#ff7eb3]', label: 'ECB記者会見' },
+  employment: { color: 'text-[#00d4aa]', dot: 'bg-[#00d4aa]', label: '米雇用統計' },
+  cpi: { color: 'text-[#f0b429]', dot: 'bg-[#f0b429]', label: 'CPI' },
+  gdp: { color: 'text-[#00c4d4]', dot: 'bg-[#00c4d4]', label: 'GDP' },
+  pce: { color: 'text-[#e0a030]', dot: 'bg-[#e0a030]', label: 'PCE' },
+  ism: { color: 'text-[#20b2aa]', dot: 'bg-[#20b2aa]', label: 'ISM' },
+  tankan: { color: 'text-[#7b68ee]', dot: 'bg-[#7b68ee]', label: '短観' },
+  earnings: { color: 'text-[#ff8c42]', dot: 'bg-[#ff8c42]', label: '決算' },
+  other: { color: 'text-[#666]', dot: 'bg-[#666]', label: 'その他' },
 }
 
 const weekDays = ['日', '月', '火', '水', '木', '金', '土']
@@ -29,12 +29,11 @@ const weekDays = ['日', '月', '火', '水', '木', '金', '土']
 export default function CalendarPage() {
   const today = new Date()
   const [year, setYear] = useState(today.getFullYear())
-  const [month, setMonth] = useState(today.getMonth() + 1) // 1-based
+  const [month, setMonth] = useState(today.getMonth() + 1)
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
 
   const events = useMemo(() => getEventsForMonth(year, month), [year, month])
 
-  // Build calendar grid
   const calendarDays = useMemo(() => {
     const firstDay = new Date(year, month - 1, 1)
     const lastDay = new Date(year, month, 0)
@@ -42,21 +41,18 @@ export default function CalendarPage() {
     const daysInMonth = lastDay.getDate()
 
     const days: (number | null)[] = []
-    // Leading blanks
     for (let i = 0; i < startDayOfWeek; i++) {
       days.push(null)
     }
     for (let d = 1; d <= daysInMonth; d++) {
       days.push(d)
     }
-    // Trailing blanks to fill 6 rows
     while (days.length < 42) {
       days.push(null)
     }
     return days
   }, [year, month])
 
-  // Events grouped by day
   const eventsByDay = useMemo(() => {
     const map = new Map<number, CalendarEvent[]>()
     events.forEach((e) => {
@@ -67,9 +63,8 @@ export default function CalendarPage() {
     return map
   }, [events])
 
-  // Selected date events
   const selectedEvents = useMemo(() => {
-    if (!selectedDate) return events // Show all month events when no date selected
+    if (!selectedDate) return events
     return events.filter(
       (e) => e.date.getDate() === selectedDate.getDate()
     )
@@ -113,46 +108,47 @@ export default function CalendarPage() {
   }
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-2xl mx-auto">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors"
-        >
-          &larr; ホーム
-        </Link>
-
-        <h1 className="text-2xl font-bold text-slate-100 mb-6">
-          イベントカレンダー
-        </h1>
+        {/* Header */}
+        <div className="flex items-center justify-between py-4">
+          <Link
+            href="/"
+            className="text-[#666] hover:text-[#888] text-sm transition-colors"
+          >
+            ← 戻る
+          </Link>
+          <h1 className="text-lg font-bold text-white">イベントカレンダー</h1>
+          <div className="w-10" />
+        </div>
 
         {/* Month navigation */}
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between mb-3">
           <button
             onClick={prevMonth}
-            className="px-3 py-1.5 text-sm text-slate-200 hover:text-white hover:bg-slate-800 rounded-lg transition-colors"
+            className="px-3 py-1.5 text-sm text-[#888] hover:text-white hover:bg-[#1a1a1a] rounded-lg transition-colors"
           >
-            &larr; 前月
+            ← 前月
           </button>
-          <h2 className="text-lg font-semibold text-slate-100">
+          <h2 className="text-base font-semibold text-white">
             {year}年 {month}月
           </h2>
           <button
             onClick={nextMonth}
-            className="px-3 py-1.5 text-sm text-slate-200 hover:text-white hover:bg-slate-800 rounded-lg transition-colors"
+            className="px-3 py-1.5 text-sm text-[#888] hover:text-white hover:bg-[#1a1a1a] rounded-lg transition-colors"
           >
-            翌月 &rarr;
+            翌月 →
           </button>
         </div>
 
         {/* Category legend */}
-        <div className="flex flex-wrap gap-3 mb-4">
+        <div className="flex flex-wrap gap-2 mb-3">
           {(['sq', 'fomc', 'fomc_press', 'boj', 'boj_press', 'ecb_press', 'employment', 'cpi', 'gdp', 'pce', 'ism', 'tankan', 'earnings'] as EventCategory[]).map((cat) => (
-            <div key={cat} className="flex items-center gap-1.5">
+            <div key={cat} className="flex items-center gap-1">
               <span
-                className={`w-2.5 h-2.5 rounded-full ${categoryConfig[cat].dot}`}
+                className={`w-2 h-2 rounded-full ${categoryConfig[cat].dot}`}
               />
-              <span className="text-xs text-slate-400">
+              <span className="text-[10px] text-[#666]">
                 {categoryConfig[cat].label}
               </span>
             </div>
@@ -160,14 +156,13 @@ export default function CalendarPage() {
         </div>
 
         {/* Calendar grid */}
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4 mb-6">
-          {/* Weekday headers */}
-          <div className="grid grid-cols-7 mb-2">
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3 mb-4">
+          <div className="grid grid-cols-7 mb-1">
             {weekDays.map((d, i) => (
               <div
                 key={d}
-                className={`text-center text-xs font-medium py-1 ${
-                  i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-slate-500'
+                className={`text-center text-[10px] font-medium py-1 ${
+                  i === 0 ? 'text-[#ff6b6b]' : i === 6 ? 'text-[#4da6ff]' : 'text-[#555]'
                 }`}
               >
                 {d}
@@ -175,23 +170,21 @@ export default function CalendarPage() {
             ))}
           </div>
 
-          {/* Day cells */}
           <div className="grid grid-cols-7">
             {calendarDays.map((day, idx) => {
               if (day === null) {
-                return <div key={`blank-${idx}`} className="h-14" />
+                return <div key={`blank-${idx}`} className="h-12" />
               }
 
               const dayEvents = eventsByDay.get(day) || []
               const dayOfWeek = new Date(year, month - 1, day).getDay()
               const todayClass = isToday(day)
-                ? 'ring-2 ring-blue-500'
+                ? 'ring-1 ring-[#00d4aa]'
                 : ''
               const selectedClass = isSelected(day)
-                ? 'bg-slate-700'
-                : 'hover:bg-slate-800'
+                ? 'bg-[#1a1a1a]'
+                : 'hover:bg-[#0a0a0a]'
 
-              // Unique categories for this day (for dots)
               const cats = [...new Set(dayEvents.map((e) => e.category))]
 
               return (
@@ -200,25 +193,25 @@ export default function CalendarPage() {
                   onClick={() =>
                     setSelectedDate(new Date(year, month - 1, day))
                   }
-                  className={`h-14 flex flex-col items-center justify-start pt-1.5 rounded-lg transition-colors ${todayClass} ${selectedClass}`}
+                  className={`h-12 flex flex-col items-center justify-start pt-1 rounded-lg transition-colors ${todayClass} ${selectedClass}`}
                 >
                   <span
-                    className={`text-sm ${
+                    className={`text-xs ${
                       dayOfWeek === 0
-                        ? 'text-red-400'
+                        ? 'text-[#ff6b6b]'
                         : dayOfWeek === 6
-                        ? 'text-blue-400'
-                        : 'text-slate-200'
+                        ? 'text-[#4da6ff]'
+                        : 'text-[#ccc]'
                     }`}
                   >
                     {day}
                   </span>
                   {cats.length > 0 && (
-                    <div className="flex gap-0.5 mt-1">
+                    <div className="flex gap-0.5 mt-0.5">
                       {cats.slice(0, 3).map((cat) => (
                         <span
                           key={cat}
-                          className={`w-1.5 h-1.5 rounded-full ${categoryConfig[cat].dot}`}
+                          className={`w-1 h-1 rounded-full ${categoryConfig[cat].dot}`}
                         />
                       ))}
                     </div>
@@ -230,41 +223,41 @@ export default function CalendarPage() {
         </div>
 
         {/* Event list */}
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5">
-          <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest mb-4">
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+          <h2 className="text-[10px] font-medium text-[#00d4aa]/70 uppercase tracking-wider mb-3">
             {selectedDate
               ? `${selectedDate.getMonth() + 1}/${selectedDate.getDate()} のイベント`
               : `${month}月のイベント`}
           </h2>
 
           {selectedEvents.length === 0 ? (
-            <p className="text-sm text-slate-500">イベントはありません</p>
+            <p className="text-sm text-[#555]">イベントはありません</p>
           ) : (
-            <ul className="space-y-2">
+            <ul className="space-y-1.5">
               {selectedEvents.map((event) => (
                 <li
                   key={event.id}
-                  className="flex items-center gap-3 py-2 px-3 rounded-xl bg-slate-800/50"
+                  className="flex items-center gap-2.5 py-2 px-3 rounded-lg bg-[#0a0a0a] border border-[#1e1e1e]"
                 >
                   <span
-                    className={`w-2.5 h-2.5 rounded-full shrink-0 ${categoryConfig[event.category].dot}`}
+                    className={`w-2 h-2 rounded-full shrink-0 ${categoryConfig[event.category].dot}`}
                   />
                   <div className="flex-1 min-w-0">
                     <p className={`text-sm font-medium ${categoryConfig[event.category].color}`}>
                       {event.title}
                     </p>
-                    <p className="text-xs text-slate-500">
+                    <p className="text-[10px] text-[#555]">
                       {event.date.getMonth() + 1}/{event.date.getDate()}（
                       {weekDays[event.date.getDay()]}）
                     </p>
                   </div>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
+                    className={`text-[10px] px-1.5 py-0.5 rounded ${
                       event.importance === 'high'
-                        ? 'bg-red-500/20 text-red-400'
+                        ? 'bg-[#ff6b6b]/15 text-[#ff6b6b]'
                         : event.importance === 'medium'
-                        ? 'bg-yellow-500/20 text-yellow-400'
-                        : 'bg-slate-700 text-slate-400'
+                        ? 'bg-[#f0b429]/15 text-[#f0b429]'
+                        : 'bg-[#1a1a1a] text-[#555]'
                     }`}
                   >
                     {event.importance === 'high'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,22 @@
 @import "tailwindcss";
 
 :root {
-  --background: #020617; /* slate-950 */
-  --foreground: #f1f5f9; /* slate-100 */
+  --background: #000000;
+  --foreground: #e2e8f0;
+  --accent: #00d4aa;
+  --accent-dim: #00d4aa80;
+  --card-bg: #111111;
+  --card-border: #1e1e1e;
+  --surface: #0a0a0a;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
+  --color-card: var(--card-bg);
+  --color-card-border: var(--card-border);
+  --color-surface: var(--surface);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -16,4 +25,21 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Scrollbar styling for dark theme */
+::-webkit-scrollbar {
+  width: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: #333;
+  border-radius: 3px;
+}
+
+/* Bottom nav safe area */
+.pb-safe-bottom {
+  padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
-import Nav from '@/components/Nav'
+import BottomNav from '@/components/BottomNav'
 import ServiceWorkerRegister from '@/components/ServiceWorkerRegister'
 
 const geistSans = Geist({
@@ -27,11 +27,11 @@ export default function RootLayout({
   return (
     <html lang="ja" className="dark">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-950 text-slate-100 min-h-screen`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-black text-slate-100 min-h-screen`}
       >
-        <Nav />
         <ServiceWorkerRegister />
-        <div className="pt-14">{children}</div>
+        <div className="pb-safe-bottom">{children}</div>
+        <BottomNav />
       </body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,15 +15,12 @@ export default async function Home() {
   ])
 
   const openCount = openTrades.length
-  // Phase 1: 簡易含み損益（エントリー価格ベース）
-  // entry_price * quantity * multiplier の合計をポジション価値として表示
   const totalPositionValue = openTrades.reduce(
     (sum, t) => sum + t.entry_price * t.quantity * DEFAULT_MULTIPLIER,
     0
   )
   const totalMaxLoss = calculateTotalMaxLoss(openTrades)
 
-  // ポートフォリオGreeks合算（エントリー時Greeksがある未決済ポジション）
   const positionGreeks: PositionGreeks[] = openTrades
     .filter((t) => t.entry_delta !== null)
     .map((t) => ({
@@ -37,30 +34,25 @@ export default async function Home() {
   const deltaNeutral = calculateDeltaNeutralDeviation(portfolioGreeks.delta)
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] flex flex-col items-center justify-center px-4 py-16">
-      <div className="w-full max-w-3xl">
-        {/* Hero */}
-        <div className="text-center mb-12">
-          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 border border-blue-500/20 text-blue-400 text-xs font-medium mb-6">
-            <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse" />
-            日経225オプション取引サポート
-          </div>
-          <h1 className="text-4xl sm:text-5xl font-bold text-white tracking-tight mb-4">
-            取引を記録し、<br className="sm:hidden" />
-            <span className="text-blue-400">勝率を上げる</span>
-          </h1>
-          <p className="text-slate-200 text-lg max-w-xl mx-auto">
-            IV分析に基づくエントリー判断・売買履歴の記録・敗因の可視化で、トレードの質を高める
-          </p>
+    <main className="min-h-screen px-4 pt-2 pb-4">
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between py-4">
+          <h1 className="text-lg font-bold text-white">マーケット</h1>
+          <Link
+            href="/calendar"
+            className="text-[#00d4aa] text-sm font-medium hover:opacity-80 transition-opacity"
+          >
+            カレンダー
+          </Link>
         </div>
 
-        {/* IV Rank Gauges */}
-        <div className="mb-8">
-          <h2 className="text-sm font-semibold text-slate-300 mb-4 flex items-center gap-2">
-            <span className="w-2 h-2 rounded-full bg-blue-400" />
+        {/* IV Rank Section */}
+        <div className="mb-4">
+          <h2 className="text-xs font-medium text-[#00d4aa] mb-3 tracking-wider">
             ATM IVランク
           </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <IvRankGauge ivRank={ivRanks.call_iv_rank} label="コール IVランク" />
             <IvRankGauge ivRank={ivRanks.put_iv_rank} label="プット IVランク" />
           </div>
@@ -68,113 +60,95 @@ export default async function Home() {
 
         {/* Portfolio Greeks Summary */}
         {openCount > 0 && positionGreeks.length > 0 && (
-          <div className="mb-8">
+          <div className="mb-4">
             <GreeksSummary greeks={portfolioGreeks} deltaNeutral={deltaNeutral} />
           </div>
         )}
 
-        {/* Open Positions Summary */}
-        <div className="mb-8 bg-slate-900 border border-slate-800 rounded-2xl p-6">
-          <h2 className="text-sm font-semibold text-slate-300 mb-4 flex items-center gap-2">
-            <span className="w-2 h-2 rounded-full bg-amber-400" />
-            未決済ポジション
-          </h2>
-          {openCount === 0 ? (
-            <p className="text-sm text-slate-400">未決済ポジションはありません</p>
-          ) : (
-            <>
-              <div className="grid grid-cols-3 gap-4 mb-4">
-                <div>
-                  <p className="text-xs text-slate-400 mb-1">ポジション数</p>
-                  <p className="text-2xl font-bold text-amber-400 tabular-nums">
-                    {openCount}
-                    <span className="text-sm font-normal text-slate-500 ml-1">件</span>
-                  </p>
+        {/* Open Positions */}
+        <div className="mb-4">
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+            <h2 className="text-xs font-medium text-[#00d4aa] mb-3 tracking-wider">
+              未決済ポジション
+            </h2>
+            {openCount === 0 ? (
+              <p className="text-sm text-[#666]">未決済ポジションはありません</p>
+            ) : (
+              <>
+                <div className="grid grid-cols-3 gap-3 mb-4">
+                  <div>
+                    <p className="text-[10px] text-[#888] mb-0.5">ポジション数</p>
+                    <p className="text-xl font-bold text-white tabular-nums">
+                      {openCount}
+                      <span className="text-xs font-normal text-[#666] ml-1">件</span>
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-[10px] text-[#888] mb-0.5">ポジション価値</p>
+                    <p className="text-xl font-bold text-white tabular-nums">
+                      {totalPositionValue.toLocaleString()}
+                      <span className="text-xs font-normal text-[#666] ml-1">円</span>
+                    </p>
+                  </div>
+                  <MaxLossSummary totalMaxLoss={totalMaxLoss} />
                 </div>
-                <div>
-                  <p className="text-xs text-slate-400 mb-1">合計ポジション価値</p>
-                  <p className="text-2xl font-bold text-slate-100 tabular-nums">
-                    {totalPositionValue.toLocaleString()}
-                    <span className="text-sm font-normal text-slate-500 ml-1">円</span>
-                  </p>
-                </div>
-                <MaxLossSummary totalMaxLoss={totalMaxLoss} />
-              </div>
-              <div className="space-y-2">
-                {openTrades.map((trade) => (
-                  <Link
-                    key={trade.id}
-                    href={`/trades/${trade.id}`}
-                    className="flex items-center gap-3 bg-slate-800/50 hover:bg-slate-800 border border-slate-700/50 hover:border-slate-600 rounded-xl px-4 py-3 transition-all duration-150"
-                  >
-                    <span className={`flex-shrink-0 w-12 text-center text-xs font-bold py-1 rounded-lg ${
-                      trade.trade_type === 'call'
-                        ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                        : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
-                    }`}>
-                      {trade.trade_type.toUpperCase()}
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <span className="text-sm font-medium text-white">
-                        {trade.strike_price.toLocaleString()}円
+
+                <div className="space-y-1">
+                  {openTrades.map((trade) => (
+                    <Link
+                      key={trade.id}
+                      href={`/trades/${trade.id}`}
+                      className="flex items-center gap-3 bg-[#0a0a0a] hover:bg-[#1a1a1a] border border-[#1e1e1e] rounded-lg px-3 py-2.5 transition-colors"
+                    >
+                      <span className={`flex-shrink-0 w-12 text-center text-[10px] font-bold py-1 rounded ${
+                        trade.trade_type === 'call'
+                          ? 'bg-[#00d4aa]/10 text-[#00d4aa] border border-[#00d4aa]/20'
+                          : 'bg-[#ff6b6b]/10 text-[#ff6b6b] border border-[#ff6b6b]/20'
+                      }`}>
+                        {trade.trade_type.toUpperCase()}
                       </span>
-                      <span className="text-xs text-slate-400 ml-2">×{trade.quantity}枚</span>
-                    </div>
-                    <div className="text-right flex-shrink-0">
-                      <span className="text-xs text-slate-400">@ {trade.entry_price}</span>
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </>
-          )}
+                      <div className="flex-1 min-w-0">
+                        <span className="text-sm font-medium text-white">
+                          {trade.strike_price.toLocaleString()}円
+                        </span>
+                        <span className="text-xs text-[#666] ml-2">x{trade.quantity}枚</span>
+                      </div>
+                      <div className="text-right flex-shrink-0">
+                        <span className="text-xs text-[#888]">@ {trade.entry_price}</span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
         </div>
 
-        {/* Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {/* Quick Links */}
+        <div className="grid grid-cols-3 gap-3">
           <Link
             href="/trades"
-            className="group relative bg-slate-900 border border-slate-800 rounded-2xl p-6 hover:border-slate-600 hover:bg-slate-800/80 transition-all duration-200"
+            className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 hover:bg-[#1a1a1a] transition-colors"
           >
-            <div className="text-2xl mb-3">📋</div>
-            <h2 className="text-base font-semibold text-white mb-1">売買履歴</h2>
-            <p className="text-sm text-slate-300">取引の記録・閲覧・分析</p>
-            <span className="absolute bottom-4 right-4 text-slate-500 group-hover:text-slate-200 transition-colors text-sm">→</span>
+            <h2 className="text-sm font-semibold text-white mb-0.5">売買履歴</h2>
+            <p className="text-[10px] text-[#666]">取引の記録・閲覧</p>
           </Link>
 
           <Link
             href="/trades/new"
-            className="group relative bg-blue-600 border border-blue-500 rounded-2xl p-6 hover:bg-blue-500 transition-all duration-200 shadow-lg shadow-blue-900/30"
+            className="bg-[#00d4aa] rounded-xl p-4 hover:bg-[#00c49a] transition-colors"
           >
-            <div className="text-2xl mb-3">✏️</div>
-            <h2 className="text-base font-semibold text-white mb-1">取引を記録</h2>
-            <p className="text-sm text-blue-200">新規エントリーの記録</p>
-            <span className="absolute bottom-4 right-4 text-blue-300 group-hover:text-white transition-colors text-sm">→</span>
+            <h2 className="text-sm font-semibold text-black mb-0.5">取引を記録</h2>
+            <p className="text-[10px] text-black/60">新規エントリー</p>
           </Link>
 
           <Link
             href="/analytics"
-            className="group relative bg-slate-900 border border-slate-800 rounded-2xl p-6 hover:border-slate-600 hover:bg-slate-800/80 transition-all duration-200"
+            className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 hover:bg-[#1a1a1a] transition-colors"
           >
-            <div className="text-2xl mb-3">📊</div>
-            <h2 className="text-base font-semibold text-white mb-1">分析</h2>
-            <p className="text-sm text-slate-300">損益チャート・敗因分析</p>
-            <span className="absolute bottom-4 right-4 text-slate-500 group-hover:text-slate-200 transition-colors text-sm">→</span>
+            <h2 className="text-sm font-semibold text-white mb-0.5">分析</h2>
+            <p className="text-[10px] text-[#666]">損益・敗因分析</p>
           </Link>
-        </div>
-
-        {/* Features */}
-        <div className="mt-12 grid grid-cols-1 sm:grid-cols-3 gap-4 text-center">
-          {[
-            { label: 'IV分析', desc: 'ブラック・ショールズ' },
-            { label: 'LINE通知', desc: '買い時シグナル' },
-            { label: '敗因分析', desc: '勝率の可視化' },
-          ].map((f) => (
-            <div key={f.label} className="py-4 border-t border-slate-800">
-              <p className="text-sm font-medium text-slate-100">{f.label}</p>
-              <p className="text-xs text-slate-400 mt-0.5">{f.desc}</p>
-            </div>
-          ))}
         </div>
       </div>
     </main>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -71,33 +71,36 @@ export default function SettingsPage() {
 
   if (loading) {
     return (
-      <main className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center">
-        <p className="text-slate-400">読み込み中...</p>
+      <main className="min-h-screen flex items-center justify-center">
+        <p className="text-[#555]">読み込み中...</p>
       </main>
     )
   }
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-16">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl font-bold text-white mb-8">通知設定</h1>
+        {/* Header */}
+        <div className="py-4">
+          <h1 className="text-lg font-bold text-white">メニュー</h1>
+        </div>
 
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
-          <h2 className="text-sm font-semibold text-slate-300 mb-4">
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+          <h2 className="text-[10px] font-medium text-[#00d4aa]/70 uppercase tracking-wider mb-3">
             取引スタイル
           </h2>
-          <p className="text-sm text-slate-400 mb-6">
+          <p className="text-xs text-[#666] mb-4">
             取引スタイルに応じてIVシグナル通知をフィルタリングします。
           </p>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             {styleOptions.map((option) => (
               <label
                 key={option.value}
-                className={`flex items-start gap-3 p-4 rounded-xl border cursor-pointer transition-all duration-150 ${
+                className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-all ${
                   tradingStyle === option.value
-                    ? 'border-blue-500 bg-blue-500/10'
-                    : 'border-slate-700 hover:border-slate-600 bg-slate-800/50'
+                    ? 'border-[#00d4aa] bg-[#00d4aa]/10'
+                    : 'border-[#2a2a2a] hover:border-[#333] bg-[#0a0a0a]'
                 }`}
               >
                 <input
@@ -106,13 +109,13 @@ export default function SettingsPage() {
                   value={option.value}
                   checked={tradingStyle === option.value}
                   onChange={() => setTradingStyle(option.value)}
-                  className="mt-1 accent-blue-500"
+                  className="mt-0.5 accent-[#00d4aa]"
                 />
                 <div>
                   <span className="text-sm font-medium text-white">
                     {option.label}
                   </span>
-                  <p className="text-xs text-slate-400 mt-1">
+                  <p className="text-[10px] text-[#666] mt-0.5">
                     {getFilterDescription(option.value)}
                   </p>
                 </div>
@@ -123,15 +126,15 @@ export default function SettingsPage() {
           <button
             onClick={handleSave}
             disabled={saving}
-            className="mt-6 w-full px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-xl transition-colors"
+            className="mt-4 w-full px-4 py-2.5 text-sm font-medium text-black bg-[#00d4aa] hover:bg-[#00c49a] disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
           >
             {saving ? '保存中...' : '設定を保存'}
           </button>
 
           {message && (
             <p
-              className={`mt-4 text-sm text-center ${
-                message.includes('失敗') ? 'text-red-400' : 'text-emerald-400'
+              className={`mt-3 text-xs text-center ${
+                message.includes('失敗') ? 'text-[#ff6b6b]' : 'text-[#00d4aa]'
               }`}
             >
               {message}

--- a/src/app/trades/[id]/DeleteButton.tsx
+++ b/src/app/trades/[id]/DeleteButton.tsx
@@ -28,7 +28,7 @@ export default function DeleteButton({ tradeId }: { tradeId: string }) {
     <button
       onClick={handleDelete}
       disabled={loading}
-      className="px-4 py-2.5 bg-slate-800 hover:bg-red-500/10 border border-slate-700 hover:border-red-500/30 text-slate-400 hover:text-red-400 text-sm font-medium rounded-xl transition-all disabled:opacity-50"
+      className="px-4 py-2.5 bg-[#1a1a1a] hover:bg-[#ff6b6b]/10 border border-[#2a2a2a] hover:border-[#ff6b6b]/30 text-[#666] hover:text-[#ff6b6b] text-sm font-medium rounded-lg transition-all disabled:opacity-50"
     >
       {loading ? '...' : '削除'}
     </button>

--- a/src/app/trades/[id]/edit/page.tsx
+++ b/src/app/trades/[id]/edit/page.tsx
@@ -8,9 +8,9 @@ import { updateTrade } from '@/app/actions/trades'
 import type { Trade } from '@/types/database'
 
 const inputClass =
-  'w-full bg-slate-800 border border-slate-700 text-slate-100 rounded-xl px-3 py-2.5 text-sm placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
+  'w-full bg-[#0a0a0a] border border-[#2a2a2a] text-white rounded-lg px-3 py-2.5 text-sm placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa] transition-colors'
 
-const labelClass = 'block text-xs font-medium text-slate-200 mb-1.5'
+const labelClass = 'block text-[10px] font-medium text-[#00d4aa]/70 mb-1 tracking-wider uppercase'
 
 export default function EditTradePage({ params }: { params: Promise<{ id: string }> }) {
   const router = useRouter()
@@ -81,29 +81,32 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
 
   if (!trade) {
     return (
-      <main className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center">
-        <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+      <main className="min-h-screen flex items-center justify-center">
+        <div className="w-5 h-5 border-2 border-[#00d4aa] border-t-transparent rounded-full animate-spin" />
       </main>
     )
   }
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-xl mx-auto">
-        <Link
-          href={`/trades/${tradeId}`}
-          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors"
-        >
-          ← 取引詳細
-        </Link>
-        <h1 className="text-2xl font-bold text-slate-100 mb-8">
-          {isSettle ? '決済を記録' : '取引を編集'}
-        </h1>
+        {/* Header */}
+        <div className="flex items-center justify-between py-4">
+          <Link
+            href={`/trades/${tradeId}`}
+            className="text-[#666] hover:text-[#888] text-sm transition-colors"
+          >
+            ← 戻る
+          </Link>
+          <h1 className="text-lg font-bold text-white">
+            {isSettle ? '決済を記録' : '取引を編集'}
+          </h1>
+          <div className="w-10" />
+        </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
           {isSettle ? (
             <>
-              {/* 決済モード: hidden fields */}
               <input type="hidden" name="trade_date" value={trade.trade_date} />
               <input type="hidden" name="trade_type" value={trade.trade_type} />
               <input type="hidden" name="strike_price" value={trade.strike_price} />
@@ -113,96 +116,92 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
               <input type="hidden" name="iv_at_entry" value={trade.iv_at_entry ?? ''} />
               <input type="hidden" name="memo" value={trade.memo ?? ''} />
 
-              {/* 決済対象の確認表示 */}
-              <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5">
-                <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-widest mb-4">決済対象</h2>
-                <div className="flex items-center gap-3 mb-3">
-                  <span className={`text-sm font-bold px-3 py-1 rounded-lg ${
+              <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+                <h2 className={labelClass}>決済対象</h2>
+                <div className="flex items-center gap-3 mb-2 mt-2">
+                  <span className={`text-xs font-bold px-2.5 py-1 rounded ${
                     trade.trade_type === 'call'
-                      ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                      : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
+                      ? 'bg-[#00d4aa]/10 text-[#00d4aa] border border-[#00d4aa]/20'
+                      : 'bg-[#ff6b6b]/10 text-[#ff6b6b] border border-[#ff6b6b]/20'
                   }`}>
                     {trade.trade_type.toUpperCase()}
                   </span>
-                  <span className="text-slate-300 font-semibold">{trade.strike_price.toLocaleString()}円</span>
-                  <span className="text-slate-500 text-sm">×{trade.quantity}枚</span>
+                  <span className="text-white font-semibold">{trade.strike_price.toLocaleString()}円</span>
+                  <span className="text-[#666] text-xs">x{trade.quantity}枚</span>
                 </div>
-                <p className="text-sm text-slate-500">購入価格: <span className="text-slate-300 font-mono">{trade.entry_price}円</span></p>
+                <p className="text-xs text-[#666]">購入価格: <span className="text-white font-mono">{trade.entry_price}円</span></p>
               </div>
             </>
           ) : (
-            /* 編集モード */
-            <>
-              <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-                <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">基本情報</h2>
+            <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 space-y-3">
+              <h2 className={labelClass}>基本情報</h2>
 
-                <div>
-                  <label className={labelClass}>種別 *</label>
-                  <div className="flex gap-2">
-                    {(['call', 'put'] as const).map((t) => (
-                      <button
-                        key={t}
-                        type="button"
-                        onClick={() => setTradeType(t)}
-                        className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all ${
-                          tradeType === t
-                            ? t === 'call'
-                              ? 'bg-blue-600 text-white border border-blue-500'
-                              : 'bg-orange-600 text-white border border-orange-500'
-                            : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
-                        }`}
-                      >
-                        {t.toUpperCase()}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className={labelClass}>取引日 *</label>
-                    <input name="trade_date" type="date" required defaultValue={trade.trade_date} className={inputClass} />
-                  </div>
-                  <div>
-                    <label className={labelClass}>限月（SQ日）*</label>
-                    <input name="expiry_date" type="date" required defaultValue={trade.expiry_date ?? ''} className={inputClass} />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className={labelClass}>権利行使価格 *</label>
-                    <input name="strike_price" type="number" required defaultValue={trade.strike_price} className={inputClass} />
-                  </div>
-                  <div>
-                    <label className={labelClass}>枚数 *</label>
-                    <input name="quantity" type="number" required min="1" defaultValue={trade.quantity} className={inputClass} />
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <div>
-                    <label className={labelClass}>購入価格 *</label>
-                    <input name="entry_price" type="number" step="0.01" required defaultValue={trade.entry_price} className={inputClass} />
-                  </div>
-                  <div>
-                    <label className={labelClass}>IV（%）</label>
-                    <input name="iv_at_entry" type="number" step="0.01" defaultValue={trade.iv_at_entry ?? ''} className={inputClass} />
-                  </div>
-                </div>
-
-                <div>
-                  <label className={labelClass}>エントリー理由・メモ</label>
-                  <textarea name="memo" rows={3} defaultValue={trade.memo ?? ''} className={`${inputClass} resize-none`} />
+              <div>
+                <label className={labelClass}>種別</label>
+                <div className="flex gap-2">
+                  {(['call', 'put'] as const).map((t) => (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => setTradeType(t)}
+                      className={`flex-1 py-2.5 rounded-lg text-sm font-semibold transition-all ${
+                        tradeType === t
+                          ? t === 'call'
+                            ? 'bg-[#00d4aa] text-black'
+                            : 'bg-[#ff6b6b] text-white'
+                          : 'bg-[#1a1a1a] text-[#555] border border-[#2a2a2a] hover:border-[#333]'
+                      }`}
+                    >
+                      {t.toUpperCase()}
+                    </button>
+                  ))}
                 </div>
               </div>
-            </>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelClass}>取引日</label>
+                  <input name="trade_date" type="date" required defaultValue={trade.trade_date} className={inputClass} />
+                </div>
+                <div>
+                  <label className={labelClass}>限月（SQ日）</label>
+                  <input name="expiry_date" type="date" required defaultValue={trade.expiry_date ?? ''} className={inputClass} />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelClass}>権利行使価格</label>
+                  <input name="strike_price" type="number" required defaultValue={trade.strike_price} className={inputClass} />
+                </div>
+                <div>
+                  <label className={labelClass}>枚数</label>
+                  <input name="quantity" type="number" required min="1" defaultValue={trade.quantity} className={inputClass} />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelClass}>購入価格</label>
+                  <input name="entry_price" type="number" step="0.01" required defaultValue={trade.entry_price} className={inputClass} />
+                </div>
+                <div>
+                  <label className={labelClass}>IV（%）</label>
+                  <input name="iv_at_entry" type="number" step="0.01" defaultValue={trade.iv_at_entry ?? ''} className={inputClass} />
+                </div>
+              </div>
+
+              <div>
+                <label className={labelClass}>メモ</label>
+                <textarea name="memo" rows={3} defaultValue={trade.memo ?? ''} className={`${inputClass} resize-none`} />
+              </div>
+            </div>
           )}
 
-          {/* 決済情報（編集・決済共通） */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">決済情報</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Settlement Info */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 space-y-3">
+            <h2 className={labelClass}>決済情報</h2>
+            <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>決済価格</label>
                 <input
@@ -227,7 +226,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
           </div>
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 text-red-400 text-sm p-3 rounded-xl">
+            <div className="bg-[#ff6b6b]/10 border border-[#ff6b6b]/20 text-[#ff6b6b] text-sm p-3 rounded-lg">
               {error}
             </div>
           )}
@@ -235,7 +234,7 @@ export default function EditTradePage({ params }: { params: Promise<{ id: string
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-3 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-semibold rounded-xl transition-colors"
+            className="w-full py-3 bg-[#00d4aa] hover:bg-[#00c49a] disabled:opacity-50 text-black font-semibold rounded-lg transition-colors"
           >
             {loading ? '保存中...' : isSettle ? '決済を保存' : '変更を保存'}
           </button>

--- a/src/app/trades/[id]/page.tsx
+++ b/src/app/trades/[id]/page.tsx
@@ -29,71 +29,78 @@ export default async function TradeDetailPage({
   const isCall = trade.trade_type === 'call'
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-xl mx-auto">
-        <Link
-          href="/trades"
-          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors"
-        >
-          ← 売買履歴
-        </Link>
-
         {/* Header */}
-        <div className="flex items-start justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <span className={`text-sm font-bold px-3 py-1 rounded-lg ${
+        <div className="flex items-center justify-between py-4">
+          <Link
+            href="/trades"
+            className="text-[#666] hover:text-[#888] text-sm transition-colors"
+          >
+            ← 戻る
+          </Link>
+          <h1 className="text-lg font-bold text-white">
+            OP {trade.trade_type.toUpperCase()} {trade.strike_price.toLocaleString()}
+          </h1>
+          <div className="w-10" />
+        </div>
+
+        {/* Status & PnL */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <span className={`text-xs font-bold px-2.5 py-1 rounded ${
               isCall
-                ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
+                ? 'bg-[#00d4aa]/10 text-[#00d4aa] border border-[#00d4aa]/20'
+                : 'bg-[#ff6b6b]/10 text-[#ff6b6b] border border-[#ff6b6b]/20'
             }`}>
               {trade.trade_type.toUpperCase()}
             </span>
-            <span className={`text-xs px-2.5 py-1 rounded-lg ${
+            <span className={`text-[10px] px-2 py-1 rounded ${
               isOpen
-                ? 'bg-amber-500/10 text-amber-400 border border-amber-500/20'
-                : 'bg-slate-800 text-slate-500 border border-slate-700'
+                ? 'bg-[#f0b429]/10 text-[#f0b429] border border-[#f0b429]/20'
+                : 'bg-[#1a1a1a] text-[#555] border border-[#2a2a2a]'
             }`}>
               {isOpen ? '未決済' : '決済済'}
             </span>
           </div>
           {trade.pnl !== null && (
-            <span className={`text-2xl font-bold tabular-nums ${trade.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+            <span className={`text-xl font-bold tabular-nums ${trade.pnl >= 0 ? 'text-[#00d4aa]' : 'text-[#ff6b6b]'}`}>
               {trade.pnl >= 0 ? '+' : ''}{trade.pnl.toLocaleString()}円
             </span>
           )}
         </div>
 
         {/* Detail Card */}
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl overflow-hidden mb-4">
-          <div className="divide-y divide-slate-800">
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl overflow-hidden mb-4">
+          <div className="divide-y divide-[#1e1e1e]">
             <Row label="権利行使価格">
-              <span className="text-lg font-semibold text-slate-100">{trade.strike_price.toLocaleString()}円</span>
+              <span className="text-base font-semibold text-white">{trade.strike_price.toLocaleString()}円</span>
             </Row>
             <Row label="限月（SQ日）">{trade.expiry_date ?? '—'}</Row>
             <Row label="取引日">{trade.trade_date}</Row>
             <Row label="枚数">{trade.quantity} 枚</Row>
             <Row label="購入価格">
-              <span className="font-mono">{trade.entry_price} 円</span>
+              <span className="font-mono text-white">{trade.entry_price} 円</span>
             </Row>
             {trade.exit_price !== null && (
               <Row label="決済価格">
-                <span className="font-mono">{trade.exit_price} 円</span>
+                <span className="font-mono text-white">{trade.exit_price} 円</span>
               </Row>
             )}
             {trade.exit_date && (
               <Row label="決済日">{trade.exit_date}</Row>
             )}
             {trade.iv_at_entry !== null && (
-              <Row label="IV（エントリー時）">
-                <span className="font-mono text-blue-400">{trade.iv_at_entry}%</span>
+              <Row label="IV">
+                <span className="font-mono text-[#00d4aa]">{trade.iv_at_entry}%</span>
               </Row>
             )}
           </div>
 
           {trade.memo && (
-            <div className="px-5 py-4 border-t border-slate-800 bg-slate-800/30">
-              <p className="text-xs text-slate-300 mb-2 uppercase tracking-widest">エントリー理由・メモ</p>
-              <p className="text-sm text-slate-300 whitespace-pre-wrap leading-relaxed">{trade.memo}</p>
+            <div className="px-4 py-3 border-t border-[#1e1e1e] bg-[#0a0a0a]">
+              <p className="text-[10px] text-[#00d4aa]/70 mb-1 uppercase tracking-wider">メモ</p>
+              <p className="text-sm text-[#ccc] whitespace-pre-wrap leading-relaxed">{trade.memo}</p>
             </div>
           )}
         </div>
@@ -103,14 +110,14 @@ export default async function TradeDetailPage({
           {isOpen && (
             <Link
               href={`/trades/${trade.id}/edit?settle=true`}
-              className="flex-1 text-center py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium rounded-xl transition-colors"
+              className="flex-1 text-center py-2.5 bg-[#00d4aa] hover:bg-[#00c49a] text-black text-sm font-medium rounded-lg transition-colors"
             >
               決済を記録
             </Link>
           )}
           <Link
             href={`/trades/${trade.id}/edit`}
-            className="flex-1 text-center py-2.5 bg-slate-800 hover:bg-slate-700 border border-slate-700 text-slate-300 text-sm font-medium rounded-xl transition-colors"
+            className="flex-1 text-center py-2.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#2a2a2a] text-[#888] text-sm font-medium rounded-lg transition-colors"
           >
             編集
           </Link>
@@ -123,9 +130,9 @@ export default async function TradeDetailPage({
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between px-5 py-3.5">
-      <span className="text-sm text-slate-300">{label}</span>
-      <span className="text-sm text-slate-200">{children}</span>
+    <div className="flex items-center justify-between px-4 py-3">
+      <span className="text-xs text-[#00d4aa]/70">{label}</span>
+      <span className="text-sm text-[#ccc]">{children}</span>
     </div>
   )
 }

--- a/src/app/trades/new/page.tsx
+++ b/src/app/trades/new/page.tsx
@@ -9,9 +9,9 @@ import type { BSInputs } from '@/lib/black-scholes'
 import { DEFEAT_TAG_CATEGORIES, MARKET_ENV_AXES, type DefeatTag } from '@/lib/tags'
 
 const inputClass =
-  'w-full bg-slate-800 border border-slate-700 text-slate-100 rounded-xl px-3 py-2.5 text-sm placeholder-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors'
+  'w-full bg-[#0a0a0a] border border-[#2a2a2a] text-white rounded-lg px-3 py-2.5 text-sm placeholder-[#444] focus:outline-none focus:ring-1 focus:ring-[#00d4aa] focus:border-[#00d4aa] transition-colors'
 
-const labelClass = 'block text-xs font-medium text-slate-200 mb-1.5'
+const labelClass = 'block text-[10px] font-medium text-[#00d4aa]/80 mb-1 tracking-wider uppercase'
 
 export default function NewTradePage() {
   const router = useRouter()
@@ -19,18 +19,15 @@ export default function NewTradePage() {
   const [error, setError] = useState<string | null>(null)
   const [tradeType, setTradeType] = useState<'call' | 'put'>('call')
 
-  // タグ選択
   const [selectedDefeatTags, setSelectedDefeatTags] = useState<string[]>([])
   const [selectedMarketEnvTags, setSelectedMarketEnvTags] = useState<string[]>([])
 
-  // Greeks計算用の入力状態
   const [spotPrice, setSpotPrice] = useState<string>('')
   const [strikePrice, setStrikePrice] = useState<string>('')
   const [ivAtEntry, setIvAtEntry] = useState<string>('')
   const [expiryDate, setExpiryDate] = useState<string>('')
   const [greeks, setGreeks] = useState<Greeks | null>(null)
 
-  // Greeks自動計算
   const computeGreeks = useCallback(() => {
     const spot = parseFloat(spotPrice)
     const strike = parseFloat(strikePrice)
@@ -41,7 +38,6 @@ export default function NewTradePage() {
       return
     }
 
-    // 満期までの年数を計算
     const now = new Date()
     const expiry = new Date(expiryDate)
     const diffMs = expiry.getTime() - now.getTime()
@@ -56,7 +52,7 @@ export default function NewTradePage() {
       spot,
       strike,
       timeToExpiry,
-      volatility: iv / 100, // %から小数に変換
+      volatility: iv / 100,
       riskFreeRate: 0.001,
       dividendYield: 0.02,
       optionType: tradeType,
@@ -133,45 +129,44 @@ export default function NewTradePage() {
   }
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-xl mx-auto">
-        <Link href="/trades" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-300 mb-6 transition-colors">
-          ← 売買履歴
-        </Link>
-        <h1 className="text-2xl font-bold text-slate-100 mb-8">取引を記録</h1>
+        {/* Header */}
+        <div className="flex items-center justify-between py-4">
+          <Link href="/trades" className="text-[#666] hover:text-[#888] text-sm transition-colors">
+            ← 戻る
+          </Link>
+          <h1 className="text-lg font-bold text-white">新規記録</h1>
+          <div className="w-10" />
+        </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          {/* Section: 基本情報 */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">基本情報</h2>
-
-            {/* CALL / PUT toggle */}
-            <div>
-              <label className={labelClass}>種別 *</label>
-              <div className="flex gap-2">
-                {(['call', 'put'] as const).map((t) => (
-                  <button
-                    key={t}
-                    type="button"
-                    onClick={() => setTradeType(t)}
-                    className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition-all ${
-                      tradeType === t
-                        ? t === 'call'
-                          ? 'bg-blue-600 text-white border border-blue-500'
-                          : 'bg-orange-600 text-white border border-orange-500'
-                        : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
-                    }`}
-                  >
-                    {t.toUpperCase()}
-                  </button>
-                ))}
-              </div>
-              <input type="hidden" name="trade_type" value={tradeType} />
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* CALL / PUT toggle */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+            <label className={labelClass}>種別</label>
+            <div className="flex gap-2">
+              {(['call', 'put'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setTradeType(t)}
+                  className={`flex-1 py-2.5 rounded-lg text-sm font-semibold transition-all ${
+                    tradeType === t
+                      ? t === 'call'
+                        ? 'bg-[#00d4aa] text-black'
+                        : 'bg-[#ff6b6b] text-white'
+                      : 'bg-[#1a1a1a] text-[#555] border border-[#2a2a2a] hover:border-[#333]'
+                  }`}
+                >
+                  {t.toUpperCase()}
+                </button>
+              ))}
             </div>
+            <input type="hidden" name="trade_type" value={tradeType} />
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-3 mt-4">
               <div>
-                <label className={labelClass}>取引日 *</label>
+                <label className={labelClass}>取引日</label>
                 <input
                   name="trade_date"
                   type="date"
@@ -181,7 +176,7 @@ export default function NewTradePage() {
                 />
               </div>
               <div>
-                <label className={labelClass}>限月（SQ日）*</label>
+                <label className={labelClass}>限月（SQ日）</label>
                 <input
                   name="expiry_date"
                   type="date"
@@ -193,9 +188,9 @@ export default function NewTradePage() {
               </div>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-3 mt-3">
               <div>
-                <label className={labelClass}>権利行使価格 *</label>
+                <label className={labelClass}>権利行使価格</label>
                 <input
                   name="strike_price"
                   type="number"
@@ -207,7 +202,7 @@ export default function NewTradePage() {
                 />
               </div>
               <div>
-                <label className={labelClass}>枚数 *</label>
+                <label className={labelClass}>枚数</label>
                 <input
                   name="quantity"
                   type="number"
@@ -220,12 +215,12 @@ export default function NewTradePage() {
             </div>
           </div>
 
-          {/* Section: 価格 */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">価格</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Price Section */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 space-y-3">
+            <h2 className={labelClass}>価格</h2>
+            <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className={labelClass}>購入価格（プレミアム）*</label>
+                <label className={labelClass}>購入価格（プレミアム）</label>
                 <input
                   name="entry_price"
                   type="number"
@@ -248,7 +243,7 @@ export default function NewTradePage() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>先物価格（原資産）</label>
                 <input
@@ -272,7 +267,7 @@ export default function NewTradePage() {
                 />
               </div>
             </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>決済日（任意）</label>
                 <input
@@ -284,60 +279,47 @@ export default function NewTradePage() {
             </div>
           </div>
 
-          {/* Section: Greeks（自動計算） */}
+          {/* Greeks */}
           {greeks && (
-            <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-              <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">
-                Greeks（BS Merton版・自動計算）
-              </h2>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-slate-500 mb-1">Delta</div>
-                  <div className="text-lg font-mono font-semibold text-slate-100">
-                    {greeks.delta >= 0 ? '+' : ''}{greeks.delta.toFixed(4)}
+            <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+              <h2 className={labelClass}>Greeks（自動計算）</h2>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mt-2">
+                {[
+                  { label: 'Delta(δ)', value: `${greeks.delta >= 0 ? '+' : ''}${greeks.delta.toFixed(4)}` },
+                  { label: 'Gamma(γ)', value: greeks.gamma.toFixed(6) },
+                  { label: 'Theta(θ)', value: `${greeks.theta >= 0 ? '+' : ''}${greeks.theta.toFixed(2)}` },
+                  { label: 'Vega(κ)', value: greeks.vega.toFixed(2) },
+                ].map((g) => (
+                  <div key={g.label} className="bg-[#0a0a0a] border border-[#1e1e1e] rounded-lg p-2.5 text-center">
+                    <div className="text-[10px] text-[#00d4aa]/70 mb-0.5">{g.label}</div>
+                    <div className="text-base font-mono font-semibold text-white">
+                      {g.value}
+                    </div>
                   </div>
-                </div>
-                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-slate-500 mb-1">Gamma</div>
-                  <div className="text-lg font-mono font-semibold text-slate-100">
-                    {greeks.gamma.toFixed(6)}
-                  </div>
-                </div>
-                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-slate-500 mb-1">Theta</div>
-                  <div className="text-lg font-mono font-semibold text-slate-100">
-                    {greeks.theta >= 0 ? '+' : ''}{greeks.theta.toFixed(2)}
-                  </div>
-                </div>
-                <div className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center">
-                  <div className="text-xs text-slate-500 mb-1">Vega</div>
-                  <div className="text-lg font-mono font-semibold text-slate-100">
-                    {greeks.vega.toFixed(2)}
-                  </div>
-                </div>
+                ))}
               </div>
-              <p className="text-xs text-slate-600">
-                r=0.1%, q=2.0% で計算。Theta は1日あたり、Vega は IV 1%変化あたりの値。
+              <p className="text-[10px] text-[#444] mt-2">
+                r=0.1%, q=2.0% で計算
               </p>
             </div>
           )}
 
-          {/* Section: 市場環境タグ */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">市場環境タグ</h2>
+          {/* Market Env Tags */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 space-y-3">
+            <h2 className={labelClass}>市場環境タグ</h2>
             {Object.entries(MARKET_ENV_AXES).map(([axis, config]) => (
               <div key={axis}>
-                <label className={labelClass}>{config.label}</label>
-                <div className="flex flex-wrap gap-2">
+                <label className="block text-[10px] text-[#888] mb-1">{config.label}</label>
+                <div className="flex flex-wrap gap-1.5">
                   {config.tags.map((tag) => (
                     <button
                       key={tag}
                       type="button"
                       onClick={() => toggleMarketEnvTag(axis, tag)}
-                      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                      className={`px-2.5 py-1 rounded text-[11px] font-medium transition-all ${
                         selectedMarketEnvTags.includes(tag)
-                          ? 'bg-emerald-600 text-white border border-emerald-500'
-                          : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                          ? 'bg-[#00d4aa] text-black'
+                          : 'bg-[#1a1a1a] text-[#666] border border-[#2a2a2a] hover:border-[#333]'
                       }`}
                     >
                       {tag}
@@ -348,23 +330,23 @@ export default function NewTradePage() {
             ))}
           </div>
 
-          {/* Section: 敗因タグ */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">敗因タグ</h2>
-            <p className="text-xs text-slate-600">該当するものを複数選択できます</p>
+          {/* Defeat Tags */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4 space-y-3">
+            <h2 className={labelClass}>敗因タグ</h2>
+            <p className="text-[10px] text-[#444]">該当するものを複数選択できます</p>
             {Object.entries(DEFEAT_TAG_CATEGORIES).map(([category, tags]) => (
               <div key={category}>
-                <label className={labelClass}>{category}</label>
-                <div className="flex flex-wrap gap-2">
+                <label className="block text-[10px] text-[#888] mb-1">{category}</label>
+                <div className="flex flex-wrap gap-1.5">
                   {tags.map((tag: DefeatTag) => (
                     <button
                       key={tag}
                       type="button"
                       onClick={() => toggleDefeatTag(tag)}
-                      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                      className={`px-2.5 py-1 rounded text-[11px] font-medium transition-all ${
                         selectedDefeatTags.includes(tag)
-                          ? 'bg-red-600 text-white border border-red-500'
-                          : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                          ? 'bg-[#ff6b6b] text-white'
+                          : 'bg-[#1a1a1a] text-[#666] border border-[#2a2a2a] hover:border-[#333]'
                       }`}
                     >
                       {tag}
@@ -375,22 +357,19 @@ export default function NewTradePage() {
             ))}
           </div>
 
-          {/* Section: メモ */}
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5 space-y-4">
-            <h2 className="text-xs font-semibold text-slate-300 uppercase tracking-widest">メモ</h2>
-            <div>
-              <label className={labelClass}>エントリー理由</label>
-              <textarea
-                name="memo"
-                rows={3}
-                placeholder="なぜこのタイミングでエントリーしたか..."
-                className={`${inputClass} resize-none`}
-              />
-            </div>
+          {/* Memo */}
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+            <h2 className={labelClass}>メモ</h2>
+            <textarea
+              name="memo"
+              rows={3}
+              placeholder="なぜこのタイミングでエントリーしたか..."
+              className={`${inputClass} resize-none`}
+            />
           </div>
 
           {error && (
-            <div className="bg-red-500/10 border border-red-500/20 text-red-400 text-sm p-3 rounded-xl">
+            <div className="bg-[#ff6b6b]/10 border border-[#ff6b6b]/20 text-[#ff6b6b] text-sm p-3 rounded-lg">
               {error}
             </div>
           )}
@@ -398,7 +377,7 @@ export default function NewTradePage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-3 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-semibold rounded-xl transition-colors"
+            className="w-full py-3 bg-[#00d4aa] hover:bg-[#00c49a] disabled:opacity-50 text-black font-semibold rounded-lg transition-colors"
           >
             {loading ? '保存中...' : '記録する'}
           </button>

--- a/src/app/trades/page.tsx
+++ b/src/app/trades/page.tsx
@@ -26,24 +26,24 @@ export default async function TradesPage() {
   const winRate = closedTrades.length > 0 ? Math.round((winCount / closedTrades.length) * 100) : null
 
   return (
-    <main className="min-h-[calc(100vh-3.5rem)] px-4 py-8">
+    <main className="min-h-screen px-4 pt-2 pb-4">
       <div className="max-w-3xl mx-auto">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold text-white">売買履歴</h1>
+        <div className="flex items-center justify-between py-4">
+          <h1 className="text-lg font-bold text-white">売買履歴</h1>
           <div className="flex items-center gap-2">
             {trades.length > 0 && (
               <a
                 href="/api/trades/export"
                 download="trades.csv"
-                className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white text-sm font-medium rounded-xl transition-colors"
+                className="px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] text-[#888] text-xs font-medium rounded-lg border border-[#2a2a2a] transition-colors"
               >
-                CSVエクスポート
+                CSV
               </a>
             )}
             <Link
               href="/trades/new"
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors"
+              className="px-3 py-1.5 bg-[#00d4aa] hover:bg-[#00c49a] text-black text-xs font-medium rounded-lg transition-colors"
             >
               + 新規記録
             </Link>
@@ -52,28 +52,28 @@ export default async function TradesPage() {
 
         {/* Stats */}
         {trades.length > 0 && (
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <p className="text-xs text-slate-300 mb-1">累計損益</p>
-              <p className={`text-xl font-bold tabular-nums ${totalPnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+          <div className="grid grid-cols-3 gap-2 mb-4">
+            <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3">
+              <p className="text-[10px] text-[#888] mb-0.5">累計損益</p>
+              <p className={`text-lg font-bold tabular-nums ${totalPnl >= 0 ? 'text-[#00d4aa]' : 'text-[#ff6b6b]'}`}>
                 {totalPnl >= 0 ? '+' : ''}{totalPnl.toLocaleString()}
-                <span className="text-sm font-normal text-slate-500 ml-1">円</span>
+                <span className="text-[10px] font-normal text-[#555] ml-0.5">円</span>
               </p>
             </div>
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <p className="text-xs text-slate-300 mb-1">勝率</p>
-              <p className="text-xl font-bold text-slate-100">
+            <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3">
+              <p className="text-[10px] text-[#888] mb-0.5">勝率</p>
+              <p className="text-lg font-bold text-white">
                 {winRate !== null ? `${winRate}%` : '—'}
                 {winRate !== null && (
-                  <span className="text-sm font-normal text-slate-500 ml-1">{winCount}/{closedTrades.length}勝</span>
+                  <span className="text-[10px] font-normal text-[#555] ml-0.5">{winCount}/{closedTrades.length}勝</span>
                 )}
               </p>
             </div>
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <p className="text-xs text-slate-300 mb-1">未決済</p>
-              <p className="text-xl font-bold text-amber-400">
+            <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-3">
+              <p className="text-[10px] text-[#888] mb-0.5">未決済</p>
+              <p className="text-lg font-bold text-[#f0b429]">
                 {openCount}
-                <span className="text-sm font-normal text-slate-500 ml-1">ポジション</span>
+                <span className="text-[10px] font-normal text-[#555] ml-0.5">件</span>
               </p>
             </div>
           </div>
@@ -81,31 +81,30 @@ export default async function TradesPage() {
 
         {/* List */}
         {trades.length === 0 ? (
-          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-16 text-center">
-            <p className="text-4xl mb-4">📋</p>
-            <p className="text-slate-400 mb-6">まだ取引の記録がありません</p>
+          <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-12 text-center">
+            <p className="text-[#555] mb-4">まだ取引の記録がありません</p>
             <Link
               href="/trades/new"
-              className="inline-block px-5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium rounded-xl transition-colors"
+              className="inline-block px-4 py-2 bg-[#00d4aa] hover:bg-[#00c49a] text-black text-sm font-medium rounded-lg transition-colors"
             >
               最初の取引を記録する
             </Link>
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-1">
             {trades.map((trade) => (
               <Link
                 key={trade.id}
                 href={`/trades/${trade.id}`}
-                className="group flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 bg-slate-900 border border-slate-800 hover:border-slate-700 hover:bg-slate-800/60 rounded-xl px-4 py-3.5 transition-all duration-150"
+                className="group flex flex-col sm:flex-row sm:items-center gap-1.5 sm:gap-3 bg-[#111] border border-[#1e1e1e] hover:border-[#2a2a2a] hover:bg-[#1a1a1a] rounded-lg px-3 py-3 transition-all"
               >
                 {/* Mobile: top row with badge + PnL */}
                 <div className="flex items-center justify-between sm:contents">
                   {/* Type Badge */}
-                  <div className={`flex-shrink-0 w-14 text-center text-xs font-bold py-1 rounded-lg ${
+                  <div className={`flex-shrink-0 w-14 text-center text-[10px] font-bold py-1 rounded ${
                     trade.trade_type === 'call'
-                      ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20'
-                      : 'bg-orange-500/10 text-orange-400 border border-orange-500/20'
+                      ? 'bg-[#00d4aa]/10 text-[#00d4aa] border border-[#00d4aa]/20'
+                      : 'bg-[#ff6b6b]/10 text-[#ff6b6b] border border-[#ff6b6b]/20'
                   }`}>
                     {trade.trade_type.toUpperCase()}
                   </div>
@@ -116,17 +115,17 @@ export default async function TradesPage() {
                       <span className="text-sm font-medium text-white">
                         {trade.strike_price.toLocaleString()}円
                       </span>
-                      <span className="text-xs text-slate-400">×{trade.quantity}枚</span>
+                      <span className="text-xs text-[#666]">x{trade.quantity}枚</span>
                       {trade.iv_at_entry !== null && (
-                        <span className="text-xs text-slate-400">IV {trade.iv_at_entry}%</span>
+                        <span className="text-xs text-[#00d4aa]/70">IV {trade.iv_at_entry}%</span>
                       )}
                     </div>
                     <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-xs text-slate-300">{trade.trade_date}</span>
-                      <span className={`text-xs px-1.5 py-0.5 rounded ${
+                      <span className="text-xs text-[#888]">{trade.trade_date}</span>
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded ${
                         trade.status === 'open'
-                          ? 'text-amber-400 bg-amber-500/10'
-                          : 'text-slate-500 bg-slate-800'
+                          ? 'text-[#f0b429] bg-[#f0b429]/10'
+                          : 'text-[#555] bg-[#1a1a1a]'
                       }`}>
                         {trade.status === 'open' ? '未決済' : '決済済'}
                       </span>
@@ -137,19 +136,19 @@ export default async function TradesPage() {
                   <div className="flex-shrink-0 text-right flex items-center gap-2">
                     {trade.pnl !== null ? (
                       <span className={`text-sm font-semibold tabular-nums ${
-                        trade.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'
+                        trade.pnl >= 0 ? 'text-[#00d4aa]' : 'text-[#ff6b6b]'
                       }`}>
                         {trade.pnl >= 0 ? '+' : ''}{trade.pnl.toLocaleString()}円
                       </span>
                     ) : (
                       <div className="flex flex-col items-end">
-                        <span className="text-xs text-slate-400">@ {trade.entry_price}</span>
-                        <span className="text-xs text-red-400/80 tabular-nums">
+                        <span className="text-xs text-[#888]">@ {trade.entry_price}</span>
+                        <span className="text-[10px] text-[#ff6b6b]/70 tabular-nums">
                           最大損失 {calculateMaxLoss(trade).toLocaleString()}円
                         </span>
                       </div>
                     )}
-                    <span className="text-slate-700 group-hover:text-slate-500 transition-colors text-sm flex-shrink-0">›</span>
+                    <span className="text-[#333] group-hover:text-[#555] transition-colors text-sm flex-shrink-0">›</span>
                   </div>
                 </div>
 
@@ -159,15 +158,15 @@ export default async function TradesPage() {
                     <span className="text-sm font-medium text-white">
                       {trade.strike_price.toLocaleString()}円
                     </span>
-                    <span className="text-xs text-slate-400">×{trade.quantity}枚</span>
+                    <span className="text-xs text-[#666]">x{trade.quantity}枚</span>
                     {trade.iv_at_entry !== null && (
-                      <span className="text-xs text-slate-400">IV {trade.iv_at_entry}%</span>
+                      <span className="text-xs text-[#00d4aa]/70">IV {trade.iv_at_entry}%</span>
                     )}
-                    <span className="text-xs text-slate-300">{trade.trade_date}</span>
-                    <span className={`text-xs px-1.5 py-0.5 rounded ${
+                    <span className="text-xs text-[#888]">{trade.trade_date}</span>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded ${
                       trade.status === 'open'
-                        ? 'text-amber-400 bg-amber-500/10'
-                        : 'text-slate-500 bg-slate-800'
+                        ? 'text-[#f0b429] bg-[#f0b429]/10'
+                        : 'text-[#555] bg-[#1a1a1a]'
                     }`}>
                       {trade.status === 'open' ? '未決済' : '決済済'}
                     </span>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+const navItems = [
+  {
+    href: '/',
+    label: 'マーケット',
+    icon: (active: boolean) => (
+      <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6" stroke={active ? '#00d4aa' : '#666'} strokeWidth={1.5}>
+        <circle cx="12" cy="12" r="10" />
+        <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+      </svg>
+    ),
+  },
+  {
+    href: '/trades',
+    label: '履歴',
+    icon: (active: boolean) => (
+      <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6" stroke={active ? '#00d4aa' : '#666'} strokeWidth={1.5}>
+        <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2" />
+        <rect x="9" y="3" width="6" height="4" rx="1" />
+        <path d="M9 12h6M9 16h4" />
+      </svg>
+    ),
+  },
+  {
+    href: '/trades/new',
+    label: '記録',
+    icon: (active: boolean) => (
+      <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6" stroke={active ? '#00d4aa' : '#666'} strokeWidth={2}>
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+    ),
+  },
+  {
+    href: '/analytics',
+    label: '分析',
+    icon: (active: boolean) => (
+      <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6" stroke={active ? '#00d4aa' : '#666'} strokeWidth={1.5}>
+        <path d="M3 3v18h18" />
+        <path d="M7 16l4-4 4 2 5-6" />
+      </svg>
+    ),
+  },
+  {
+    href: '/settings',
+    label: 'メニュー',
+    icon: (active: boolean) => (
+      <svg viewBox="0 0 24 24" fill="none" className="w-6 h-6" stroke={active ? '#00d4aa' : '#666'} strokeWidth={1.5}>
+        <path d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    ),
+  },
+]
+
+export default function BottomNav() {
+  const pathname = usePathname()
+
+  // Don't show on auth pages
+  if (pathname.startsWith('/auth')) return null
+
+  return (
+    <nav className="fixed bottom-0 inset-x-0 z-50 bg-[#0a0a0a] border-t border-[#1e1e1e]" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
+      <div className="flex items-center justify-around h-16 max-w-lg mx-auto">
+        {navItems.map((item) => {
+          const isActive = item.href === '/'
+            ? pathname === '/'
+            : pathname.startsWith(item.href) && !(item.href === '/trades' && pathname === '/trades/new')
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex flex-col items-center gap-0.5 px-3 py-1 min-w-[60px] transition-colors ${
+                isActive ? 'text-[#00d4aa]' : 'text-[#666]'
+              }`}
+            >
+              {item.icon(isActive)}
+              <span className="text-[10px] font-medium">{item.label}</span>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/src/components/GreeksSummary.tsx
+++ b/src/components/GreeksSummary.tsx
@@ -17,20 +17,19 @@ export function GreeksSummary({ greeks, deltaNeutral }: GreeksSummaryProps) {
   ]
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
-      <h2 className="text-sm font-semibold text-slate-300 mb-4 flex items-center gap-2">
-        <span className="w-2 h-2 rounded-full bg-purple-400" />
+    <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+      <h2 className="text-xs font-medium text-[#00d4aa] mb-3 tracking-wider">
         ポートフォリオ Greeks
       </h2>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-3">
         {greeksItems.map((item) => (
           <div key={item.key}>
-            <p className="text-xs text-slate-400 mb-1">{item.label}</p>
-            <p className="text-lg font-bold text-slate-100 tabular-nums">
+            <p className="text-[10px] text-[#00d4aa]/70 mb-0.5">{item.label}</p>
+            <p className="text-lg font-bold text-white tabular-nums font-mono">
               {item.value.toFixed(item.decimals)}
               {item.suffix && (
-                <span className="text-xs font-normal text-slate-500 ml-0.5">
+                <span className="text-[10px] font-normal text-[#555] ml-0.5">
                   {item.suffix}
                 </span>
               )}
@@ -40,22 +39,22 @@ export function GreeksSummary({ greeks, deltaNeutral }: GreeksSummaryProps) {
       </div>
 
       {/* デルタ中立乖離度 */}
-      <div className={`rounded-xl px-4 py-3 border ${
+      <div className={`rounded-lg px-3 py-2.5 border ${
         deltaNeutral.isWarning
-          ? 'bg-red-500/10 border-red-500/30'
-          : 'bg-slate-800/50 border-slate-700/50'
+          ? 'bg-[#ff6b6b]/10 border-[#ff6b6b]/30'
+          : 'bg-[#0a0a0a] border-[#1e1e1e]'
       }`}>
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs text-slate-400 mb-0.5">デルタ中立乖離度</p>
-            <p className={`text-xl font-bold tabular-nums ${
-              deltaNeutral.isWarning ? 'text-red-400' : 'text-slate-100'
+            <p className="text-[10px] text-[#888] mb-0.5">デルタ中立乖離度</p>
+            <p className={`text-lg font-bold tabular-nums font-mono ${
+              deltaNeutral.isWarning ? 'text-[#ff6b6b]' : 'text-white'
             }`}>
               {deltaNeutral.deviation.toFixed(4)}
             </p>
           </div>
           {deltaNeutral.isWarning && (
-            <span className="text-xs font-medium px-2 py-1 rounded-lg bg-red-500/20 text-red-400 border border-red-500/30">
+            <span className="text-[10px] font-medium px-2 py-1 rounded bg-[#ff6b6b]/20 text-[#ff6b6b] border border-[#ff6b6b]/30">
               閾値超過
             </span>
           )}

--- a/src/components/IvRankAnalysis.tsx
+++ b/src/components/IvRankAnalysis.tsx
@@ -17,7 +17,6 @@ export default function IvRankAnalysis({ trades }: Props) {
   const bands = useMemo(() => calculateIvRankWinRates(trades), [trades])
   const hasData = bands.some((b) => b.totalTrades > 0)
 
-  // Scatter data: trades with both iv_rank and pnl
   const scatterData = useMemo(
     () =>
       trades
@@ -37,11 +36,11 @@ export default function IvRankAnalysis({ trades }: Props) {
 
   if (!hasData) {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-8 text-center">
-        <p className="text-slate-400">
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-8 text-center">
+        <p className="text-[#555]">
           IVランクデータのある決済済み取引がありません
         </p>
-        <p className="text-slate-500 text-sm mt-2">
+        <p className="text-[#444] text-xs mt-2">
           取引記録時に「エントリー時IVランク」を入力すると分析が表示されます
         </p>
       </div>
@@ -49,51 +48,44 @@ export default function IvRankAnalysis({ trades }: Props) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       {/* Scatter Chart */}
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
-        <h3 className="text-lg font-semibold text-slate-100 mb-4">
-          IVランク × 損益 散布図
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-white mb-3">
+          IVランク x 損益 散布図
         </h3>
-        <div className="relative w-full h-64">
-          {/* Y axis label */}
-          <div className="absolute -left-2 top-1/2 -translate-y-1/2 -rotate-90 text-xs text-slate-500">
+        <div className="relative w-full h-56">
+          <div className="absolute -left-2 top-1/2 -translate-y-1/2 -rotate-90 text-[10px] text-[#555]">
             損益
           </div>
-          {/* X axis label */}
-          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 text-xs text-slate-500">
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[10px] text-[#555]">
             IVランク
           </div>
-          {/* Chart area */}
-          <div className="ml-6 mb-6 relative w-[calc(100%-1.5rem)] h-[calc(100%-1.5rem)] border-l border-b border-slate-700">
-            {/* Zero line */}
+          <div className="ml-6 mb-6 relative w-[calc(100%-1.5rem)] h-[calc(100%-1.5rem)] border-l border-b border-[#2a2a2a]">
             <div
-              className="absolute left-0 right-0 border-t border-dashed border-slate-700"
+              className="absolute left-0 right-0 border-t border-dashed border-[#2a2a2a]"
               style={{ top: '50%' }}
             />
-            {/* X axis ticks */}
             {[0, 25, 50, 75, 100].map((tick) => (
               <div
                 key={tick}
-                className="absolute bottom-0 translate-y-4 text-xs text-slate-500 -translate-x-1/2"
+                className="absolute bottom-0 translate-y-4 text-[10px] text-[#555] -translate-x-1/2"
                 style={{ left: `${tick}%` }}
               >
                 {tick}
               </div>
             ))}
-            {/* Data points */}
             {scatterData.map((d) => {
               const x = (d.ivRank / 100) * 100
-              // Map pnl to 0-100%, where 50% is zero
               const y = 50 + (d.pnl / maxAbsPnl) * 50
               const clampedY = Math.max(2, Math.min(98, y))
               return (
                 <div
                   key={d.id}
-                  className={`absolute w-2.5 h-2.5 rounded-full -translate-x-1/2 -translate-y-1/2 ${
+                  className={`absolute w-2 h-2 rounded-full -translate-x-1/2 -translate-y-1/2 ${
                     d.pnl >= 0
-                      ? 'bg-emerald-400 shadow-emerald-400/30'
-                      : 'bg-red-400 shadow-red-400/30'
+                      ? 'bg-[#00d4aa] shadow-[#00d4aa]/30'
+                      : 'bg-[#ff6b6b] shadow-[#ff6b6b]/30'
                   } shadow-lg`}
                   style={{
                     left: `${x}%`,
@@ -105,37 +97,37 @@ export default function IvRankAnalysis({ trades }: Props) {
             })}
           </div>
         </div>
-        <div className="flex gap-4 justify-center mt-2 text-xs text-slate-400">
+        <div className="flex gap-4 justify-center mt-1 text-[10px] text-[#666]">
           <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full bg-emerald-400 inline-block" />
+            <span className="w-2 h-2 rounded-full bg-[#00d4aa] inline-block" />
             利益
           </span>
           <span className="flex items-center gap-1">
-            <span className="w-2.5 h-2.5 rounded-full bg-red-400 inline-block" />
+            <span className="w-2 h-2 rounded-full bg-[#ff6b6b] inline-block" />
             損失
           </span>
         </div>
       </div>
 
       {/* Win Rate Table */}
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
-        <h3 className="text-lg font-semibold text-slate-100 mb-4">
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+        <h3 className="text-sm font-semibold text-white mb-3">
           IVランク帯別 勝率
         </h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-700">
-                <th className="text-left py-3 px-4 text-slate-400 font-medium">
+              <tr className="border-b border-[#1e1e1e]">
+                <th className="text-left py-2 px-3 text-[10px] text-[#00d4aa]/70 font-medium">
                   IVランク帯
                 </th>
-                <th className="text-right py-3 px-4 text-slate-400 font-medium">
+                <th className="text-right py-2 px-3 text-[10px] text-[#00d4aa]/70 font-medium">
                   取引数
                 </th>
-                <th className="text-right py-3 px-4 text-slate-400 font-medium">
+                <th className="text-right py-2 px-3 text-[10px] text-[#00d4aa]/70 font-medium">
                   勝率
                 </th>
-                <th className="text-right py-3 px-4 text-slate-400 font-medium">
+                <th className="text-right py-2 px-3 text-[10px] text-[#00d4aa]/70 font-medium">
                   平均損益
                 </th>
               </tr>
@@ -144,40 +136,40 @@ export default function IvRankAnalysis({ trades }: Props) {
               {bands.map((band) => (
                 <tr
                   key={band.label}
-                  className="border-b border-slate-800 last:border-0"
+                  className="border-b border-[#1e1e1e]/50 last:border-0"
                 >
-                  <td className="py-3 px-4 text-slate-200">{band.label}</td>
-                  <td className="py-3 px-4 text-right text-slate-300">
+                  <td className="py-2.5 px-3 text-[#ccc]">{band.label}</td>
+                  <td className="py-2.5 px-3 text-right text-[#888]">
                     {band.totalTrades}
                   </td>
-                  <td className="py-3 px-4 text-right">
+                  <td className="py-2.5 px-3 text-right">
                     {band.winRate != null ? (
                       <span
                         className={
                           band.winRate >= 50
-                            ? 'text-emerald-400'
-                            : 'text-red-400'
+                            ? 'text-[#00d4aa]'
+                            : 'text-[#ff6b6b]'
                         }
                       >
                         {band.winRate.toFixed(1)}%
                       </span>
                     ) : (
-                      <span className="text-slate-500">-</span>
+                      <span className="text-[#555]">-</span>
                     )}
                   </td>
-                  <td className="py-3 px-4 text-right">
+                  <td className="py-2.5 px-3 text-right">
                     {band.averagePnl != null ? (
                       <span
                         className={
                           band.averagePnl >= 0
-                            ? 'text-emerald-400'
-                            : 'text-red-400'
+                            ? 'text-[#00d4aa]'
+                            : 'text-[#ff6b6b]'
                         }
                       >
                         {formatPnl(Math.round(band.averagePnl))}
                       </span>
                     ) : (
-                      <span className="text-slate-500">-</span>
+                      <span className="text-[#555]">-</span>
                     )}
                   </td>
                 </tr>

--- a/src/components/IvRankGauge.tsx
+++ b/src/components/IvRankGauge.tsx
@@ -7,22 +7,22 @@ interface IvRankGaugeProps {
 
 function getColor(ivRank: number): { bar: string; text: string; label: string } {
   if (ivRank < 25) {
-    return { bar: 'bg-emerald-500', text: 'text-emerald-400', label: '買い好機' }
+    return { bar: 'bg-[#00d4aa]', text: 'text-[#00d4aa]', label: '買い好機' }
   } else if (ivRank < 75) {
-    return { bar: 'bg-slate-500', text: 'text-slate-400', label: '中立' }
+    return { bar: 'bg-[#888]', text: 'text-[#888]', label: '中立' }
   } else {
-    return { bar: 'bg-red-500', text: 'text-red-400', label: '売り好機' }
+    return { bar: 'bg-[#ff6b6b]', text: 'text-[#ff6b6b]', label: '売り好機' }
   }
 }
 
 export function IvRankGauge({ ivRank, label = 'IVランク' }: IvRankGaugeProps) {
   if (ivRank === null) {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5">
-        <p className="text-sm font-semibold text-slate-300 mb-3">{label}</p>
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+        <p className="text-xs font-medium text-[#888] mb-2">{label}</p>
         <div className="flex items-center gap-2">
-          <span className="w-2 h-2 rounded-full bg-slate-600" />
-          <p className="text-sm text-slate-500">データなし</p>
+          <span className="w-1.5 h-1.5 rounded-full bg-[#333]" />
+          <p className="text-sm text-[#555]">データなし</p>
         </div>
       </div>
     )
@@ -32,33 +32,30 @@ export function IvRankGauge({ ivRank, label = 'IVランク' }: IvRankGaugeProps)
   const color = getColor(clamped)
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-5">
-      <div className="flex items-center justify-between mb-3">
-        <p className="text-sm font-semibold text-slate-300">{label}</p>
-        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${color.text} bg-slate-800 border border-slate-700`}>
+    <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-[#888]">{label}</p>
+        <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${color.text} bg-[#1a1a1a] border border-[#2a2a2a]`}>
           {color.label}
         </span>
       </div>
-      {/* Value */}
-      <p className={`text-3xl font-bold tabular-nums mb-3 ${color.text}`}>
+      <p className={`text-2xl font-bold tabular-nums mb-2 ${color.text}`}>
         {clamped.toFixed(1)}
-        <span className="text-sm font-normal text-slate-500 ml-1">/ 100</span>
+        <span className="text-xs font-normal text-[#555] ml-1">/ 100</span>
       </p>
-      {/* Progress bar */}
-      <div className="w-full h-2.5 bg-slate-800 rounded-full overflow-hidden">
+      <div className="w-full h-2 bg-[#1a1a1a] rounded-full overflow-hidden">
         <div
           data-testid="iv-gauge-bar"
           className={`h-full rounded-full transition-all duration-500 ${color.bar}`}
           style={{ width: `${clamped}%` }}
         />
       </div>
-      {/* Scale labels */}
-      <div className="flex justify-between mt-1.5">
-        <span className="text-[10px] text-emerald-500/60">0</span>
-        <span className="text-[10px] text-slate-500">25</span>
-        <span className="text-[10px] text-slate-500">50</span>
-        <span className="text-[10px] text-slate-500">75</span>
-        <span className="text-[10px] text-red-500/60">100</span>
+      <div className="flex justify-between mt-1">
+        <span className="text-[9px] text-[#00d4aa]/50">0</span>
+        <span className="text-[9px] text-[#555]">25</span>
+        <span className="text-[9px] text-[#555]">50</span>
+        <span className="text-[9px] text-[#555]">75</span>
+        <span className="text-[9px] text-[#ff6b6b]/50">100</span>
       </div>
     </div>
   )

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -16,7 +16,7 @@ export default function LogoutButton() {
   return (
     <button
       onClick={handleLogout}
-      className="px-3 py-1.5 text-sm text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg transition-colors"
+      className="px-3 py-1.5 text-sm text-[#666] hover:text-[#ff6b6b] rounded-lg transition-colors"
     >
       ログアウト
     </button>

--- a/src/components/MaxLossSummary.tsx
+++ b/src/components/MaxLossSummary.tsx
@@ -7,10 +7,10 @@ interface MaxLossSummaryProps {
 export function MaxLossSummary({ totalMaxLoss }: MaxLossSummaryProps) {
   return (
     <div>
-      <p className="text-xs text-slate-400 mb-1">最大損失額</p>
-      <p className="text-2xl font-bold text-red-400 tabular-nums">
+      <p className="text-[10px] text-[#888] mb-0.5">最大損失額</p>
+      <p className="text-xl font-bold text-[#ff6b6b] tabular-nums">
         {totalMaxLoss.toLocaleString()}
-        <span className="text-sm font-normal text-slate-500 ml-1">円</span>
+        <span className="text-xs font-normal text-[#666] ml-1">円</span>
       </p>
     </div>
   )

--- a/src/components/PnlChart.tsx
+++ b/src/components/PnlChart.tsx
@@ -21,37 +21,42 @@ function formatYen(value: number): string {
   return value.toLocaleString()
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const pnlFormatter = (value: any) => [`${Number(value).toLocaleString()}円`, '累計損益']
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dailyFormatter = (value: any) => [`${Number(value).toLocaleString()}円`, '日次損益']
+
 export function PnlChart({ data }: { data: PnlChartDataPoint[] }) {
   if (data.length === 0) {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-12 text-center">
-        <p className="text-slate-400">決済済み取引がありません</p>
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-12 text-center">
+        <p className="text-[#555]">決済済み取引がありません</p>
       </div>
     )
   }
 
   return (
-    <div data-testid="pnl-chart-container" className="space-y-8">
+    <div data-testid="pnl-chart-container" className="space-y-6 mb-6">
       <section>
-        <h2 className="text-lg font-semibold text-slate-100 mb-4">累計損益推移</h2>
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4">
+        <h2 className="text-sm font-semibold text-white mb-3">累計損益推移</h2>
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
           <ResponsiveContainer width="100%" height={300}>
             <LineChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
-              <XAxis dataKey="date" stroke="#94a3b8" fontSize={12} />
-              <YAxis stroke="#94a3b8" fontSize={12} tickFormatter={formatYen} />
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e1e1e" />
+              <XAxis dataKey="date" stroke="#555" fontSize={11} />
+              <YAxis stroke="#555" fontSize={11} tickFormatter={formatYen} />
               <Tooltip
-                contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
-                labelStyle={{ color: '#e2e8f0' }}
-                formatter={(value: number) => [`${value.toLocaleString()}円`, '累計損益']}
+                contentStyle={{ backgroundColor: '#111', border: '1px solid #2a2a2a', borderRadius: '8px' }}
+                labelStyle={{ color: '#ccc' }}
+                formatter={pnlFormatter}
               />
-              <ReferenceLine y={0} stroke="#475569" />
+              <ReferenceLine y={0} stroke="#333" />
               <Line
                 type="monotone"
                 dataKey="cumulative"
-                stroke="#38bdf8"
+                stroke="#00d4aa"
                 strokeWidth={2}
-                dot={{ fill: '#38bdf8', r: 3 }}
+                dot={{ fill: '#00d4aa', r: 3 }}
               />
             </LineChart>
           </ResponsiveContainer>
@@ -59,22 +64,22 @@ export function PnlChart({ data }: { data: PnlChartDataPoint[] }) {
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold text-slate-100 mb-4">日次損益</h2>
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-4">
+        <h2 className="text-sm font-semibold text-white mb-3">日次損益</h2>
+        <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
           <ResponsiveContainer width="100%" height={300}>
             <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
-              <XAxis dataKey="date" stroke="#94a3b8" fontSize={12} />
-              <YAxis stroke="#94a3b8" fontSize={12} tickFormatter={formatYen} />
+              <CartesianGrid strokeDasharray="3 3" stroke="#1e1e1e" />
+              <XAxis dataKey="date" stroke="#555" fontSize={11} />
+              <YAxis stroke="#555" fontSize={11} tickFormatter={formatYen} />
               <Tooltip
-                contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px' }}
-                labelStyle={{ color: '#e2e8f0' }}
-                formatter={(value: number) => [`${value.toLocaleString()}円`, '日次損益']}
+                contentStyle={{ backgroundColor: '#111', border: '1px solid #2a2a2a', borderRadius: '8px' }}
+                labelStyle={{ color: '#ccc' }}
+                formatter={dailyFormatter}
               />
-              <ReferenceLine y={0} stroke="#475569" />
+              <ReferenceLine y={0} stroke="#333" />
               <Bar
                 dataKey="daily"
-                fill="#38bdf8"
+                fill="#00d4aa"
                 radius={[4, 4, 0, 0]}
               />
             </BarChart>

--- a/src/components/VolatilitySkewChart.tsx
+++ b/src/components/VolatilitySkewChart.tsx
@@ -16,12 +16,15 @@ interface VolatilitySkewChartProps {
   data: SkewDataPoint[]
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const skewFormatter = (value: any) => [`${Number(value).toFixed(2)}%`]
+
 export default function VolatilitySkewChart({ data }: VolatilitySkewChartProps) {
   if (data.length === 0) {
     return (
-      <div className="bg-slate-900 border border-slate-800 rounded-2xl p-12 text-center">
-        <p className="text-slate-400">スキューデータがありません</p>
-        <p className="text-slate-500 text-sm mt-2">
+      <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-12 text-center">
+        <p className="text-[#555]">スキューデータがありません</p>
+        <p className="text-[#444] text-xs mt-2">
           IV履歴にATM・OTMプットの両方のデータが必要です
         </p>
       </div>
@@ -36,48 +39,48 @@ export default function VolatilitySkewChart({ data }: VolatilitySkewChartProps) 
   }))
 
   return (
-    <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6">
-      <h2 className="text-lg font-semibold text-slate-100 mb-4">
+    <div className="bg-[#111] border border-[#1e1e1e] rounded-xl p-4">
+      <h2 className="text-sm font-semibold text-white mb-2">
         ボラティリティ・スキュー推移
       </h2>
-      <p className="text-slate-500 text-sm mb-6">
-        OTMプットIV − ATM IV（スキューが大きいほど市場のリスク警戒が強い）
+      <p className="text-[#555] text-[10px] mb-4">
+        OTMプットIV - ATM IV（スキューが大きいほど市場のリスク警戒が強い）
       </p>
-      <div className="w-full h-80">
+      <div className="w-full h-72">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartData} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+            <CartesianGrid strokeDasharray="3 3" stroke="#1e1e1e" />
             <XAxis
               dataKey="date"
-              tick={{ fill: '#94a3b8', fontSize: 12 }}
+              tick={{ fill: '#555', fontSize: 11 }}
               tickFormatter={(v: string) => v.slice(5)}
             />
             <YAxis
-              tick={{ fill: '#94a3b8', fontSize: 12 }}
+              tick={{ fill: '#555', fontSize: 11 }}
               tickFormatter={(v: number) => `${v}%`}
               width={50}
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: '#1e293b',
-                border: '1px solid #334155',
+                backgroundColor: '#111',
+                border: '1px solid #2a2a2a',
                 borderRadius: '8px',
-                color: '#e2e8f0',
+                color: '#ccc',
               }}
-              formatter={(value: number) => [`${value.toFixed(2)}%`]}
+              formatter={skewFormatter}
             />
-            <Legend wrapperStyle={{ color: '#94a3b8' }} />
+            <Legend wrapperStyle={{ color: '#888' }} />
             <Line
               type="monotone"
               dataKey="スキュー"
-              stroke="#f59e0b"
+              stroke="#f0b429"
               strokeWidth={2}
               dot={false}
             />
             <Line
               type="monotone"
               dataKey="ATM IV"
-              stroke="#3b82f6"
+              stroke="#00d4aa"
               strokeWidth={1}
               strokeDasharray="4 4"
               dot={false}
@@ -85,7 +88,7 @@ export default function VolatilitySkewChart({ data }: VolatilitySkewChartProps) 
             <Line
               type="monotone"
               dataKey="OTM Put IV"
-              stroke="#ef4444"
+              stroke="#ff6b6b"
               strokeWidth={1}
               strokeDasharray="4 4"
               dot={false}

--- a/src/lib/push-notifications.ts
+++ b/src/lib/push-notifications.ts
@@ -20,7 +20,7 @@ export async function subscribeToPush(
 ): Promise<PushSubscription> {
   const subscription = await registration.pushManager.subscribe({
     userVisibleOnly: true,
-    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as BufferSource,
   })
 
   const response = await fetch('/api/push/subscribe', {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary
- 証券会社アプリ（SBI証券等）を参考に、UI全体をプロフェッショナルなトレーディング画面に刷新
- **ダークテーマ強化**: 背景を真っ黒(#000)に、カード/サーフェスを#111/#0aに変更
- **ボトムナビゲーション**: トップナビを廃止し、モバイルファーストのアイコン付きボトムタブ（マーケット/履歴/記録/分析/メニュー）を導入
- **カラーパレット統一**: アクセントをシアン(#00d4aa)、損益を緑/赤(#ff6b6b)に統一
- **全ページ対応**: ホーム、売買履歴、新規記録、取引詳細、編集、分析、カレンダー、設定、ログイン/登録の全ページをリデザイン
- **既存バグ修正**: PnlChartのformatter型エラー、useSearchParamsのSuspense boundary、tsconfig除外設定

## 変更ファイル（23ファイル）
- `globals.css` - CSS変数をダークテーマに
- `layout.tsx` - BottomNav導入、トップナビ削除
- `BottomNav.tsx` - 新規作成（SVGアイコン付きボトムタブ）
- 全ページ/コンポーネント - カラーパレット統一

## Test plan
- [ ] 各ページの表示確認（ホーム、履歴、新規記録、詳細、編集、分析、カレンダー、設定）
- [ ] ボトムナビの遷移・アクティブ状態の確認
- [ ] モバイル表示の確認
- [ ] ログイン/登録画面の表示確認
- [ ] チャート（累計損益、スキュー）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)