### PR TITLE
feat: 感情トラッキング機能追加 & スコアリングを買い戦略向けに修正

### DIFF
--- a/src/app/api/iv-data/batch-collect/route.ts
+++ b/src/app/api/iv-data/batch-collect/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       if (ivRank <= 25) {
         signal = 'BUY' // IV低水準 → 買い好機
       } else if (ivRank >= 75) {
-        signal = 'SELL' // IV高水準 → 割高注意
+        signal = 'CAUTION' // IV高水準 → 割高注意
       } else {
         signal = 'NEUTRAL'
       }

--- a/src/app/api/iv-data/batch-collect/route.ts
+++ b/src/app/api/iv-data/batch-collect/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: Request): Promise<NextResponse> {
       if (ivRank <= 25) {
         signal = 'BUY' // IV低水準 → 買い好機
       } else if (ivRank >= 75) {
-        signal = 'SELL' // IV高水準 → 売り好機
+        signal = 'SELL' // IV高水準 → 割高注意
       } else {
         signal = 'NEUTRAL'
       }

--- a/src/components/IvRankGauge.tsx
+++ b/src/components/IvRankGauge.tsx
@@ -11,7 +11,7 @@ function getColor(ivRank: number): { bar: string; text: string; label: string } 
   } else if (ivRank < 75) {
     return { bar: 'bg-[#888]', text: 'text-[#888]', label: '中立' }
   } else {
-    return { bar: 'bg-[#ff6b6b]', text: 'text-[#ff6b6b]', label: '売り好機' }
+    return { bar: 'bg-[#ff6b6b]', text: 'text-[#ff6b6b]', label: '割高注意' }
   }
 }
 

--- a/src/components/__tests__/IvRankGauge.test.tsx
+++ b/src/components/__tests__/IvRankGauge.test.tsx
@@ -25,10 +25,10 @@ describe('IvRankGauge', () => {
     expect(gauge.className).toContain('bg-[#888]')
   })
 
-  it('75以上の値で赤色（売り好機）を表示する', () => {
+  it('75以上の値で赤色（割高注意）を表示する', () => {
     render(<IvRankGauge ivRank={85} label="ATM Call" />)
     expect(screen.getByText('85.0')).toBeDefined()
-    expect(screen.getByText('売り好機')).toBeDefined()
+    expect(screen.getByText('割高注意')).toBeDefined()
     const gauge = screen.getByTestId('iv-gauge-bar')
     expect(gauge.className).toContain('bg-[#ff6b6b]')
   })
@@ -42,7 +42,7 @@ describe('IvRankGauge', () => {
 
   it('境界値75で赤色を表示する', () => {
     render(<IvRankGauge ivRank={75} label="ATM Call" />)
-    expect(screen.getByText('売り好機')).toBeDefined()
+    expect(screen.getByText('割高注意')).toBeDefined()
     const gauge = screen.getByTestId('iv-gauge-bar')
     expect(gauge.className).toContain('bg-[#ff6b6b]')
   })
@@ -55,7 +55,7 @@ describe('IvRankGauge', () => {
 
   it('値100で正しく描画する', () => {
     render(<IvRankGauge ivRank={100} label="ATM Call" />)
-    expect(screen.getByText('売り好機')).toBeDefined()
+    expect(screen.getByText('割高注意')).toBeDefined()
   })
 
   it('ゲージバーの幅がvalue%になる', () => {

--- a/src/lib/__tests__/entry-quality-scoring.test.ts
+++ b/src/lib/__tests__/entry-quality-scoring.test.ts
@@ -75,40 +75,40 @@ describe('calculateEntryQualityScore', () => {
     expect(lowScore).toBeLessThanOrEqual(100)
   })
 
-  it('gives higher score for high IV rank (sell premium opportunity)', () => {
-    const highIvScore = calculateEntryQualityScore(makeFeatures({ ivRank: 90 }))
+  it('gives higher score for low IV rank (cheap premium = buy opportunity)', () => {
     const lowIvScore = calculateEntryQualityScore(makeFeatures({ ivRank: 10 }))
-    expect(highIvScore).toBeGreaterThan(lowIvScore)
+    const highIvScore = calculateEntryQualityScore(makeFeatures({ ivRank: 90 }))
+    expect(lowIvScore).toBeGreaterThan(highIvScore)
   })
 
-  it('gives higher score for high IV percentile', () => {
-    const highScore = calculateEntryQualityScore(makeFeatures({ ivPercentile: 90 }))
+  it('gives higher score for low IV percentile (buy opportunity)', () => {
     const lowScore = calculateEntryQualityScore(makeFeatures({ ivPercentile: 10 }))
-    expect(highScore).toBeGreaterThan(lowScore)
+    const highScore = calculateEntryQualityScore(makeFeatures({ ivPercentile: 90 }))
+    expect(lowScore).toBeGreaterThan(highScore)
   })
 
-  it('gives higher score for high PCR (more puts = fear = sell premium opportunity)', () => {
-    const highPcrScore = calculateEntryQualityScore(makeFeatures({ pcr: 1.5 }))
+  it('gives higher score for low PCR (complacency = vol expansion potential = buy opportunity)', () => {
     const lowPcrScore = calculateEntryQualityScore(makeFeatures({ pcr: 0.5 }))
-    expect(highPcrScore).toBeGreaterThan(lowPcrScore)
+    const highPcrScore = calculateEntryQualityScore(makeFeatures({ pcr: 1.5 }))
+    expect(lowPcrScore).toBeGreaterThan(highPcrScore)
   })
 
-  it('gives higher score for negative skew (steeper skew = premium selling opportunity)', () => {
+  it('gives higher score for negative skew (steeper skew = OTM put cheap = buy opportunity)', () => {
     const negSkew = calculateEntryQualityScore(makeFeatures({ skew: -5 }))
     const posSkew = calculateEntryQualityScore(makeFeatures({ skew: 5 }))
     expect(negSkew).toBeGreaterThan(posSkew)
   })
 
-  it('penalizes pre-event entries', () => {
+  it('gives bonus for pre-event entries (vol expansion expected = buy opportunity)', () => {
     const preEvent = calculateEntryQualityScore(makeFeatures({ isPreEvent: true }))
     const noEvent = calculateEntryQualityScore(makeFeatures({ isPreEvent: false }))
-    expect(preEvent).toBeLessThan(noEvent)
+    expect(preEvent).toBeGreaterThan(noEvent)
   })
 
-  it('gives slight bonus for post-event entries', () => {
+  it('penalizes post-event entries (vol crush = unfavorable for buying)', () => {
     const postEvent = calculateEntryQualityScore(makeFeatures({ isPostEvent: true }))
     const noEvent = calculateEntryQualityScore(makeFeatures({ isPostEvent: false }))
-    expect(postEvent).toBeGreaterThan(noEvent)
+    expect(postEvent).toBeLessThan(noEvent)
   })
 
   it('gives higher score on midweek days (Tue-Thu)', () => {

--- a/src/lib/__tests__/hv-calculations.test.ts
+++ b/src/lib/__tests__/hv-calculations.test.ts
@@ -110,9 +110,9 @@ describe('getIvHvSignal', () => {
     expect(getIvHvSignal(1.5)).toBe('中立')
   })
 
-  it('returns 売り好機 when ratio > 1.5', () => {
-    expect(getIvHvSignal(1.51)).toBe('売り好機')
-    expect(getIvHvSignal(2.0)).toBe('売り好機')
+  it('returns 割高注意 when ratio > 1.5', () => {
+    expect(getIvHvSignal(1.51)).toBe('割高注意')
+    expect(getIvHvSignal(2.0)).toBe('割高注意')
   })
 })
 

--- a/src/lib/__tests__/iv-calculations.test.ts
+++ b/src/lib/__tests__/iv-calculations.test.ts
@@ -4,6 +4,8 @@ import {
   buildSkewTimeSeries,
   findAtmIv,
   findOtmPutIv,
+  getIvRankLabel,
+  getIvRankColor,
 } from '../iv-calculations'
 import type { IvHistory } from '@/types/database'
 
@@ -87,6 +89,40 @@ describe('calculateSkew', () => {
 
   it('returns null when OTM put IV is null', () => {
     expect(calculateSkew(null, 0.18)).toBeNull()
+  })
+})
+
+describe('getIvRankLabel', () => {
+  it('returns 買い好機 for ivRank <= 25', () => {
+    expect(getIvRankLabel(0)).toBe('買い好機')
+    expect(getIvRankLabel(25)).toBe('買い好機')
+  })
+
+  it('returns 中立 for ivRank between 26 and 74', () => {
+    expect(getIvRankLabel(26)).toBe('中立')
+    expect(getIvRankLabel(50)).toBe('中立')
+    expect(getIvRankLabel(74)).toBe('中立')
+  })
+
+  it('returns 割高注意 for ivRank >= 75', () => {
+    expect(getIvRankLabel(75)).toBe('割高注意')
+    expect(getIvRankLabel(100)).toBe('割高注意')
+  })
+})
+
+describe('getIvRankColor', () => {
+  it('returns green for ivRank <= 25', () => {
+    expect(getIvRankColor(0)).toBe('bg-emerald-500')
+    expect(getIvRankColor(25)).toBe('bg-emerald-500')
+  })
+
+  it('returns grey for ivRank between 26 and 74', () => {
+    expect(getIvRankColor(50)).toBe('bg-slate-500')
+  })
+
+  it('returns red for ivRank >= 75', () => {
+    expect(getIvRankColor(75)).toBe('bg-red-500')
+    expect(getIvRankColor(100)).toBe('bg-red-500')
   })
 })
 

--- a/src/lib/entry-quality-scoring.ts
+++ b/src/lib/entry-quality-scoring.ts
@@ -4,7 +4,7 @@ import type { Trade } from '@/types/database'
  * エントリー品質スコアリング
  *
  * 特徴量からルールベースで0-100点のスコアを算出する。
- * 高IVランク時のプレミアム売り戦略を高評価とする。
+ * 低IVランク時のオプション買い戦略（割安なプレミアム）を高評価とする。
  */
 
 export interface EntryFeatures {
@@ -36,32 +36,33 @@ const WEIGHTS = {
 
 /**
  * IVランクのスコア (0-100)
- * 高いほど良い（プレミアム売りに有利）
+ * 低いほど良い（プレミアムが割安＝オプション買いに有利）
  */
 function scoreIvRank(ivRank: number): number {
-  return Math.max(0, Math.min(100, ivRank))
+  return Math.max(0, Math.min(100, 100 - ivRank))
 }
 
 /**
  * IVパーセンタイルのスコア (0-100)
+ * 低いほど良い（IVが相対的に低い＝買いに有利）
  */
 function scoreIvPercentile(ivPercentile: number): number {
-  return Math.max(0, Math.min(100, ivPercentile))
+  return Math.max(0, Math.min(100, 100 - ivPercentile))
 }
 
 /**
  * PCRスコア (0-100)
- * PCR > 1.0 は恐怖心理 → プレミアム売り好機
- * 0.5-2.0 の範囲を 0-100 にマッピング
+ * PCR < 1.0 は楽観 → ボラ拡大余地あり → オプション買い好機
+ * 0.5-2.0 の範囲を 100-0 にマッピング
  */
 function scorePcr(pcr: number): number {
   const clamped = Math.max(0.5, Math.min(2.0, pcr))
-  return ((clamped - 0.5) / 1.5) * 100
+  return ((2.0 - clamped) / 1.5) * 100
 }
 
 /**
  * スキュースコア (0-100)
- * 負のスキュー（スティープ）はプレミアム売り好機
+ * 負のスキュー（スティープ）はOTMプットが割安 → 買い好機
  * -10〜+10 を 100〜0 にマッピング
  */
 function scoreSkew(skew: number): number {
@@ -88,13 +89,13 @@ function scoreDayOfWeek(dayOfWeek: number): number {
 
 /**
  * イベントスコア (0-100)
- * イベント前: リスク高 → 低スコア
- * イベント後: ボラ低下 → 高スコア
+ * イベント前: ボラ拡大期待 → 買い好機 → 高スコア
+ * イベント後: ボラ収縮 → 買いに不利 → 低スコア
  * 通常時: 中程度
  */
 function scoreEvent(isPreEvent: boolean, isPostEvent: boolean): number {
-  if (isPreEvent) return 30
-  if (isPostEvent) return 80
+  if (isPreEvent) return 80
+  if (isPostEvent) return 30
   return 60
 }
 

--- a/src/lib/hv-calculations.ts
+++ b/src/lib/hv-calculations.ts
@@ -77,12 +77,12 @@ export function calculateIvHvRatio(
  */
 export function getIvHvSignal(
   ratio: number
-): '買い好機' | '中立' | '売り好機' {
+): '買い好機' | '中立' | '割高注意' {
   if (ratio < 1.0) {
     return '買い好機'
   }
   if (ratio > 1.5) {
-    return '売り好機'
+    return '割高注意'
   }
   return '中立'
 }

--- a/src/lib/iv-calculations.ts
+++ b/src/lib/iv-calculations.ts
@@ -66,9 +66,9 @@ export function calculateIvPercentile(
 
 /**
  * IVランクに基づく色を返す
- * - 0-25: 緑（買い好機） - IVが低い = オプション買いに有利
+ * - 0-25: 緑（買い好機） - IVが低い = プレミアムが割安
  * - 25-75: 黄（中立）
- * - 75-100: 赤（売り好機） - IVが高い = オプション売りに有利
+ * - 75-100: 赤（割高注意） - IVが高い = プレミアムが割高
  *
  * @param ivRank IVランク (0-100)
  * @returns Tailwind CSSカラークラス名
@@ -94,7 +94,7 @@ export function getIvRankLabel(ivRank: number): string {
     return '買い好機'
   }
   if (ivRank >= 75) {
-    return '売り好機'
+    return '割高注意'
   }
   return '中立'
 }

--- a/src/lib/trade-schema.ts
+++ b/src/lib/trade-schema.ts
@@ -116,8 +116,8 @@ export const tradeSchema = z.object({
   is_mini: z.boolean(),
   playbook_id: z.string().nullable(),
   playbook_compliance: z.boolean().nullable(),
-  confidence_level: z.number().nullable(),
-  emotion: z.string().nullable(),
+  confidence_level: z.number().nullish().transform((v) => v ?? null),
+  emotion: z.string().nullish().transform((v) => v ?? null),
 });
 
 export type Trade = z.infer<typeof tradeSchema>;


### PR DESCRIPTION
## Summary
- 取引記録時の感情（自信過剰・恐怖・FOMO等）と自信レベルを記録できる機能を追加
- エントリー品質スコアリングをプレミアム売り前提から**オプション買い向け**に修正（低IV=割安=高スコア）
- IVランク関連の「売り好機」ラベルを「割高注意」に統一
- tradeSchemaでDB未マイグレーション時のundefined許容を修正

## Changes
- `src/app/trades/new/page.tsx`: 感情・自信レベルの入力フォーム追加
- `src/lib/emotion-analysis.ts`: 感情別・自信レベル別の勝率分析
- `src/components/EmotionAnalysis.tsx`: 感情分析の表示コンポーネント
- `src/lib/entry-quality-scoring.ts`: IVランク・PCR・イベントのスコアを買い向けに反転
- `src/lib/iv-calculations.ts`, `src/lib/hv-calculations.ts`, `src/components/IvRankGauge.tsx`: 「売り好機」→「割高注意」

## Test plan
- [x] エントリー品質スコアリングのテスト（低IV=高スコアの確認）
- [x] IvRankGaugeのテスト（「割高注意」ラベル表示の確認）
- [x] hv-calculationsのテスト（IV/HVシグナルラベルの確認）
- [ ] 新規取引フォームで感情・自信レベルが保存されることを確認
- [ ] アナリティクス画面で感情分析が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)