### PR TITLE
feat: POP・エントリー品質スコアに目安表ヘルプを追加

### DIFF
--- a/src/app/trades/new/page.tsx
+++ b/src/app/trades/new/page.tsx
@@ -73,6 +73,7 @@ export default function NewTradePage() {
   const [error, setError] = useState<string | null>(null)
   const { values: draft, hasDraft, updateValues: updateDraft, clearDraft } = useFormDraft<TradeDraft>(DRAFT_KEY, createInitialDraft())
   const [playbooks, setPlaybooks] = useState<SimplePlaybook[]>([])
+  const [showPopHelp, setShowPopHelp] = useState(false)
 
   useEffect(() => {
     createBrowserSupabaseClient()
@@ -420,11 +421,40 @@ export default function NewTradePage() {
               {pop !== null && (
                 <div className="mt-3 bg-[#0a0a0a] border border-[#1e1e1e] rounded-lg p-3">
                   <div className="flex items-center justify-between">
-                    <span className="text-[10px] text-[#00d4aa]/70 uppercase tracking-wider">POP（利益確率）</span>
+                    <span className="text-[10px] text-[#00d4aa]/70 uppercase tracking-wider flex items-center gap-1">
+                      POP（利益確率）
+                      <button
+                        type="button"
+                        onClick={() => setShowPopHelp((v) => !v)}
+                        className="w-4 h-4 rounded-full border border-[#555] text-[#888] hover:text-[#00d4aa] hover:border-[#00d4aa] text-[9px] leading-none transition-colors"
+                      >
+                        ?
+                      </button>
+                    </span>
                     <span className={`text-lg font-mono font-bold ${pop >= 50 ? 'text-[#00d4aa]' : 'text-[#f0b429]'}`}>
                       {pop}%
                     </span>
                   </div>
+                  {showPopHelp && (
+                    <div className="mt-2 bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg p-3 text-[11px] text-[#aaa]">
+                      <p className="text-[#00d4aa] font-semibold mb-1.5">POP 目安表</p>
+                      <table className="w-full">
+                        <tbody>
+                          {[
+                            ['5%以下', 'かなり投機的（遠いOTM）'],
+                            ['10-30%', '典型的なOTM買い'],
+                            ['30-50%', 'ATM付近の買い'],
+                            ['50%以上', 'ITMの買い'],
+                          ].map(([range, desc]) => (
+                            <tr key={range} className="border-b border-[#2a2a2a] last:border-b-0">
+                              <td className="py-1 pr-3 font-mono text-white whitespace-nowrap">{range}</td>
+                              <td className="py-1 text-[#888]">{desc}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
                   <div className="mt-1.5 h-1.5 bg-[#1a1a1a] rounded-full overflow-hidden">
                     <div
                       className={`h-full rounded-full transition-all ${pop >= 50 ? 'bg-[#00d4aa]' : 'bg-[#f0b429]'}`}

--- a/src/components/EntryQualityScore.tsx
+++ b/src/components/EntryQualityScore.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { calculateEntryQualityScore, type EntryFeatures } from '@/lib/entry-quality-scoring'
 
 interface Props {
@@ -31,6 +32,8 @@ function getScoreLabel(score: number): string {
 }
 
 export default function EntryQualityScore({ features }: Props) {
+  const [showHelp, setShowHelp] = useState(false)
+
   if (!features) return null
 
   const score = calculateEntryQualityScore(features)
@@ -41,8 +44,15 @@ export default function EntryQualityScore({ features }: Props) {
   return (
     <div className="bg-[#0a0a0a] border border-[#1e1e1e] rounded-lg p-3">
       <div className="flex items-center justify-between">
-        <span className="text-[10px] text-[#00d4aa]/70 uppercase tracking-wider">
+        <span className="text-[10px] text-[#00d4aa]/70 uppercase tracking-wider flex items-center gap-1">
           エントリー品質スコア
+          <button
+            type="button"
+            onClick={() => setShowHelp((v) => !v)}
+            className="w-4 h-4 rounded-full border border-[#555] text-[#888] hover:text-[#00d4aa] hover:border-[#00d4aa] text-[9px] leading-none transition-colors"
+          >
+            ?
+          </button>
         </span>
         <div className="flex items-center gap-2">
           <span className="text-xs text-[#888]">{label}</span>
@@ -51,6 +61,27 @@ export default function EntryQualityScore({ features }: Props) {
           </span>
         </div>
       </div>
+      {showHelp && (
+        <div className="mt-2 bg-[#1a1a1a] border border-[#2a2a2a] rounded-lg p-3 text-[11px] text-[#aaa]">
+          <p className="text-[#00d4aa] font-semibold mb-1.5">スコア目安表</p>
+          <table className="w-full">
+            <tbody>
+              {[
+                ['81-100', '最高の好機'],
+                ['61-80', '好条件'],
+                ['41-60', '普通'],
+                ['21-40', 'やや不利'],
+                ['0-20', '不適（エントリー避けるべき）'],
+              ].map(([range, desc]) => (
+                <tr key={range} className="border-b border-[#2a2a2a] last:border-b-0">
+                  <td className="py-1 pr-3 font-mono text-white whitespace-nowrap">{range}</td>
+                  <td className="py-1 text-[#888]">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
       <div className="mt-1.5 h-1.5 bg-[#1a1a1a] rounded-full overflow-hidden">
         <div
           className={`h-full rounded-full transition-all ${barColor}`}


### PR DESCRIPTION
## Summary
- 新規記録画面のPOP（利益確率）とエントリー品質スコアの横に「?」ボタンを追加
- 「?」を押すと目安表が表示され、再度押すと閉じるトグル動作

## POP 目安表
| POP | 評価 |
|---|---|
| 5%以下 | かなり投機的（遠いOTM） |
| 10-30% | 典型的なOTM買い |
| 30-50% | ATM付近の買い |
| 50%以上 | ITMの買い |

## エントリー品質スコア目安表
| スコア | 評価 |
|---|---|
| 81-100 | 最高の好機 |
| 61-80 | 好条件 |
| 41-60 | 普通 |
| 21-40 | やや不利 |
| 0-20 | 不適（エントリー避けるべき） |

## Test plan
- [ ] POP横の「?」押下で目安表が表示されること
- [ ] 再度「?」押下で目安表が非表示になること
- [ ] エントリー品質スコア横の「?」押下で目安表が表示されること
- [ ] 再度「?」押下で目安表が非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)